### PR TITLE
Use "development" branch from git repo instead of old tar file.

### DIFF
--- a/psa-crypto-sys/Cargo.toml
+++ b/psa-crypto-sys/Cargo.toml
@@ -20,4 +20,4 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.4.2"
 
 [package.metadata.config]
-mbed-crypto-version = "mbedcrypto-2.0.0"
+mbed-crypto-commit = "5435451a1a3d0af3eef71e3883f3087df52e48d5"

--- a/psa-crypto-sys/setup_mbed_crypto.sh
+++ b/psa-crypto-sys/setup_mbed_crypto.sh
@@ -5,14 +5,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # ------------------------------------------------------------------------------
 
-MBED_VERSION=$1
-if [[ -z "$MBED_VERSION" ]]; then
-    >&2 echo "No mbed version provided."
+MBED_COMMIT=$1
+if [[ -z "$MBED_COMMIT" ]]; then
+    >&2 echo "No mbed commit provided."
     exit 1
 fi
 
-MBED_GITHUB_URL="https://github.com/ARMmbed/mbed-crypto"
-MBED_ROOT_FOLDER_NAME="mbed-crypto-$MBED_VERSION"
+MBED_GITHUB_URL="https://github.com/ARMmbed/mbedtls"
+MBED_ROOT_FOLDER_NAME="mbedtls"
 MBED_LIB_FILENAME="libmbedcrypto.a"
 MBED_SHIMLIB_DIR="src/c"
 
@@ -33,9 +33,9 @@ fi
 
 get_mbed_repo() {
     echo "No mbed-crypto present locally. Cloning."
-    wget $MBED_GITHUB_URL/archive/$MBED_VERSION.tar.gz
-    tar xf $MBED_VERSION.tar.gz
+    git clone $MBED_GITHUB_URL $MBED_ROOT_FOLDER_NAME
     pushd $MBED_ROOT_FOLDER_NAME
+    git checkout $MBED_COMMIT
 }
 
 setup_mbed_library() {

--- a/psa-crypto/src/lib.rs
+++ b/psa-crypto/src/lib.rs
@@ -177,7 +177,7 @@ pub fn psa_asymmetric_sign(
     signature_size: usize,
     signature_length: *mut usize,
 ) -> psa_status_t {
-    wrap_status!(psa_crypto_sys::psa_asymmetric_sign(
+    wrap_status!(psa_crypto_sys::psa_sign_hash(
         handle,
         alg,
         hash,
@@ -196,7 +196,7 @@ pub fn psa_asymmetric_verify(
     signature: *const u8,
     signature_length: usize,
 ) -> psa_status_t {
-    wrap_status!(psa_crypto_sys::psa_asymmetric_verify(
+    wrap_status!(psa_crypto_sys::psa_verify_hash(
         handle,
         alg,
         hash,


### PR DESCRIPTION
This would fix parallaxsecond/parsec#153.

Instead of
wget https://github.com/ARMmbed/mbed-crypto/archive/mbedcrypto-2.0.0.tar.gz
we fetch the Mbed Crypto source with:
git clone https://github.com/ARMmbed/mbedtls && git checkout $MBED_COMMIT

The MBED_COMMIT is specified in Cargo.toml and will be updated from
time to time at least until there is a stable branch we can use.

Two functions in the API have changed their names. These are renamed
in psa-crypto-sys, not in psa-crypto.

Signed-off-by: Edmund Grimley Evans <edmund.grimley-evans@arm.com>