### PR TITLE
Improve interface of both crates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+*.patch

--- a/psa-crypto-sys/Cargo.toml
+++ b/psa-crypto-sys/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["psa", "crypto", "cryptography"]
 categories = ["api-bindings", "external-ffi-bindings", "cryptography"]
 license = "Apache-2.0"
 repository = "https://github.com/parallaxsecond/rust-psa-crypto"
-links = "mbedtls"
+links = "mbedcrypto"
 
 [build-dependencies]
 bindgen = "0.50.0"

--- a/psa-crypto-sys/README.md
+++ b/psa-crypto-sys/README.md
@@ -21,3 +21,7 @@ link against it statically. In this use case enabling the `static` feature
 makes no difference and there is no way to allow dynamic linking. The
 requirements for configuring and building MbedTLS can be found
 [on their repository homepage](https://github.com/ARMmbed/mbedtls#tool-versions).
+
+Currently the version of MbedTLS built is based on the `development` branch
+of their repository, as the Mbed Crypto functionality has not yet been included in
+a standard release.

--- a/psa-crypto-sys/src/lib.rs
+++ b/psa-crypto-sys/src/lib.rs
@@ -27,167 +27,187 @@ mod psa_crypto_binding {
 
 #[allow(dead_code)]
 mod constants;
+
 pub use constants::*;
-pub use psa_crypto_binding::*;
+pub use psa_crypto_binding::psa_algorithm_t;
+pub use psa_crypto_binding::psa_close_key;
+pub use psa_crypto_binding::psa_crypto_init;
+pub use psa_crypto_binding::psa_destroy_key;
+pub use psa_crypto_binding::psa_dh_group_t;
+pub use psa_crypto_binding::psa_ecc_curve_t;
+pub use psa_crypto_binding::psa_export_public_key;
+pub use psa_crypto_binding::psa_generate_key;
+pub use psa_crypto_binding::psa_import_key;
+pub use psa_crypto_binding::psa_key_attributes_t;
+pub use psa_crypto_binding::psa_key_handle_t;
+pub use psa_crypto_binding::psa_key_id_t;
+pub use psa_crypto_binding::psa_key_lifetime_t;
+pub use psa_crypto_binding::psa_key_type_t;
+pub use psa_crypto_binding::psa_key_usage_t;
+pub use psa_crypto_binding::psa_open_key;
+pub use psa_crypto_binding::psa_reset_key_attributes;
+pub use psa_crypto_binding::psa_sign_hash;
+pub use psa_crypto_binding::psa_status_t;
+pub use psa_crypto_binding::psa_verify_hash;
 
 pub unsafe fn psa_get_key_bits(attributes: *const psa_key_attributes_t) -> usize {
-    shim_get_key_bits(attributes)
+    psa_crypto_binding::shim_get_key_bits(attributes)
 }
 
 pub unsafe fn psa_get_key_type(attributes: *const psa_key_attributes_t) -> psa_key_type_t {
-    shim_get_key_type(attributes)
+    psa_crypto_binding::shim_get_key_type(attributes)
 }
 
 pub unsafe fn psa_get_key_lifetime(attributes: *const psa_key_attributes_t) -> psa_key_lifetime_t {
-    shim_get_key_lifetime(attributes)
+    psa_crypto_binding::shim_get_key_lifetime(attributes)
 }
 
 pub unsafe fn psa_get_key_algorithm(attributes: *const psa_key_attributes_t) -> psa_algorithm_t {
-    shim_get_key_algorithm(attributes)
+    psa_crypto_binding::shim_get_key_algorithm(attributes)
 }
 
 pub unsafe fn psa_get_key_usage_flags(attributes: *const psa_key_attributes_t) -> psa_key_usage_t {
-    shim_get_key_usage_flags(attributes)
+    psa_crypto_binding::shim_get_key_usage_flags(attributes)
 }
 
 pub unsafe fn psa_key_attributes_init() -> psa_key_attributes_t {
-    shim_key_attributes_init()
+    psa_crypto_binding::shim_key_attributes_init()
 }
 
 pub unsafe fn psa_set_key_algorithm(attributes: *mut psa_key_attributes_t, alg: psa_algorithm_t) {
-    shim_set_key_algorithm(attributes, alg);
+    psa_crypto_binding::shim_set_key_algorithm(attributes, alg);
 }
 
 pub unsafe fn psa_set_key_bits(attributes: *mut psa_key_attributes_t, bits: usize) {
-    shim_set_key_bits(attributes, bits);
+    psa_crypto_binding::shim_set_key_bits(attributes, bits);
 }
 
 pub unsafe fn psa_set_key_id(attributes: *mut psa_key_attributes_t, id: psa_key_id_t) {
-    shim_set_key_id(attributes, id);
+    psa_crypto_binding::shim_set_key_id(attributes, id);
 }
 
 pub unsafe fn psa_set_key_lifetime(
     attributes: *mut psa_key_attributes_t,
     lifetime: psa_key_lifetime_t,
 ) {
-    shim_set_key_lifetime(attributes, lifetime);
+    psa_crypto_binding::shim_set_key_lifetime(attributes, lifetime);
 }
 
 pub unsafe fn psa_set_key_type(attributes: *mut psa_key_attributes_t, type_: psa_key_type_t) {
-    shim_set_key_type(attributes, type_);
+    psa_crypto_binding::shim_set_key_type(attributes, type_);
 }
 
 pub unsafe fn psa_set_key_usage_flags(
     attributes: *mut psa_key_attributes_t,
     usage_flags: psa_key_usage_t,
 ) {
-    shim_set_key_usage_flags(attributes, usage_flags);
+    psa_crypto_binding::shim_set_key_usage_flags(attributes, usage_flags);
 }
 
 pub fn PSA_ALG_IS_HASH(alg: psa_algorithm_t) -> bool {
-    unsafe { shim_PSA_ALG_IS_HASH(alg) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_HASH(alg) == 1 }
 }
 
 pub fn PSA_ALG_IS_MAC(alg: psa_algorithm_t) -> bool {
-    unsafe { shim_PSA_ALG_IS_MAC(alg) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_MAC(alg) == 1 }
 }
 
 pub fn PSA_ALG_IS_CIPHER(alg: psa_algorithm_t) -> bool {
-    unsafe { shim_PSA_ALG_IS_CIPHER(alg) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_CIPHER(alg) == 1 }
 }
 
 pub fn PSA_ALG_IS_AEAD(alg: psa_algorithm_t) -> bool {
-    unsafe { shim_PSA_ALG_IS_AEAD(alg) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_AEAD(alg) == 1 }
 }
 
 pub fn PSA_ALG_IS_SIGN(alg: psa_algorithm_t) -> bool {
-    unsafe { shim_PSA_ALG_IS_SIGN(alg) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_SIGN(alg) == 1 }
 }
 
 pub fn PSA_ALG_IS_ASYMMETRIC_ENCRYPTION(alg: psa_algorithm_t) -> bool {
-    unsafe { shim_PSA_ALG_IS_ASYMMETRIC_ENCRYPTION(alg) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_ASYMMETRIC_ENCRYPTION(alg) == 1 }
 }
 
 pub fn PSA_ALG_IS_KEY_AGREEMENT(alg: psa_algorithm_t) -> bool {
-    unsafe { shim_PSA_ALG_IS_KEY_AGREEMENT(alg) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_KEY_AGREEMENT(alg) == 1 }
 }
 
 pub fn PSA_ALG_IS_KEY_DERIVATION(alg: psa_algorithm_t) -> bool {
-    unsafe { shim_PSA_ALG_IS_KEY_DERIVATION(alg) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_KEY_DERIVATION(alg) == 1 }
 }
 
 pub fn PSA_ALG_IS_RSA_PKCS1V15_SIGN(alg: psa_algorithm_t) -> bool {
-    unsafe { shim_PSA_ALG_IS_RSA_PKCS1V15_SIGN(alg) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_RSA_PKCS1V15_SIGN(alg) == 1 }
 }
 
 pub fn PSA_ALG_IS_RSA_PSS(alg: psa_algorithm_t) -> bool {
-    unsafe { shim_PSA_ALG_IS_RSA_PSS(alg) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_RSA_PSS(alg) == 1 }
 }
 
 pub fn PSA_ALG_IS_ECDSA(alg: psa_algorithm_t) -> bool {
-    unsafe { shim_PSA_ALG_IS_ECDSA(alg) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_ECDSA(alg) == 1 }
 }
 
 pub fn PSA_ALG_IS_DETERMINISTIC_ECDSA(alg: psa_algorithm_t) -> bool {
-    unsafe { shim_PSA_ALG_IS_DETERMINISTIC_ECDSA(alg) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_DETERMINISTIC_ECDSA(alg) == 1 }
 }
 
 pub fn PSA_ALG_SIGN_GET_HASH(alg: psa_algorithm_t) -> psa_algorithm_t {
-    unsafe { shim_PSA_ALG_SIGN_GET_HASH(alg) }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_SIGN_GET_HASH(alg) }
 }
 
 pub fn PSA_ALG_RSA_PKCS1V15_SIGN(hash_alg: psa_algorithm_t) -> psa_algorithm_t {
-    unsafe { shim_PSA_ALG_RSA_PKCS1V15_SIGN(hash_alg) }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_RSA_PKCS1V15_SIGN(hash_alg) }
 }
 
 pub fn PSA_ALG_RSA_PSS(hash_alg: psa_algorithm_t) -> psa_algorithm_t {
-    unsafe { shim_PSA_ALG_RSA_PSS(hash_alg) }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_RSA_PSS(hash_alg) }
 }
 
 pub fn PSA_ALG_ECDSA(hash_alg: psa_algorithm_t) -> psa_algorithm_t {
-    unsafe { shim_PSA_ALG_ECDSA(hash_alg) }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_ECDSA(hash_alg) }
 }
 
 pub fn PSA_ALG_DETERMINISTIC_ECDSA(hash_alg: psa_algorithm_t) -> psa_algorithm_t {
-    unsafe { shim_PSA_ALG_DETERMINISTIC_ECDSA(hash_alg) }
+    unsafe { psa_crypto_binding::shim_PSA_ALG_DETERMINISTIC_ECDSA(hash_alg) }
 }
 
 pub fn PSA_KEY_TYPE_IS_ECC_KEY_PAIR(key_type: psa_key_type_t) -> bool {
-    unsafe { shim_PSA_KEY_TYPE_IS_ECC_KEY_PAIR(key_type) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_KEY_TYPE_IS_ECC_KEY_PAIR(key_type) == 1 }
 }
 
 pub fn PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type: psa_key_type_t) -> bool {
-    unsafe { shim_PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type) == 1 }
 }
 
 pub fn PSA_KEY_TYPE_IS_DH_KEY_PAIR(key_type: psa_key_type_t) -> bool {
-    unsafe { shim_PSA_KEY_TYPE_IS_DH_KEY_PAIR(key_type) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_KEY_TYPE_IS_DH_KEY_PAIR(key_type) == 1 }
 }
 
 pub fn PSA_KEY_TYPE_IS_DH_PUBLIC_KEY(key_type: psa_key_type_t) -> bool {
-    unsafe { shim_PSA_KEY_TYPE_IS_DH_PUBLIC_KEY(key_type) == 1 }
+    unsafe { psa_crypto_binding::shim_PSA_KEY_TYPE_IS_DH_PUBLIC_KEY(key_type) == 1 }
 }
 
 pub fn PSA_KEY_TYPE_GET_CURVE(key_type: psa_key_type_t) -> psa_ecc_curve_t {
-    unsafe { shim_PSA_KEY_TYPE_GET_CURVE(key_type) }
+    unsafe { psa_crypto_binding::shim_PSA_KEY_TYPE_GET_CURVE(key_type) }
 }
 
 pub fn PSA_KEY_TYPE_GET_GROUP(key_type: psa_key_type_t) -> psa_dh_group_t {
-    unsafe { shim_PSA_KEY_TYPE_GET_GROUP(key_type) }
+    unsafe { psa_crypto_binding::shim_PSA_KEY_TYPE_GET_GROUP(key_type) }
 }
 
 pub fn PSA_KEY_TYPE_ECC_KEY_PAIR(curve: psa_ecc_curve_t) -> psa_key_type_t {
-    unsafe { shim_PSA_KEY_TYPE_ECC_KEY_PAIR(curve) }
+    unsafe { psa_crypto_binding::shim_PSA_KEY_TYPE_ECC_KEY_PAIR(curve) }
 }
 
 pub fn PSA_KEY_TYPE_ECC_PUBLIC_KEY(curve: psa_ecc_curve_t) -> psa_key_type_t {
-    unsafe { shim_PSA_KEY_TYPE_ECC_PUBLIC_KEY(curve) }
+    unsafe { psa_crypto_binding::shim_PSA_KEY_TYPE_ECC_PUBLIC_KEY(curve) }
 }
 
 pub fn PSA_KEY_TYPE_DH_KEY_PAIR(group: psa_dh_group_t) -> psa_key_type_t {
-    unsafe { shim_PSA_KEY_TYPE_DH_KEY_PAIR(group) }
+    unsafe { psa_crypto_binding::shim_PSA_KEY_TYPE_DH_KEY_PAIR(group) }
 }
 
 pub fn PSA_KEY_TYPE_DH_PUBLIC_KEY(group: psa_dh_group_t) -> psa_key_type_t {
-    unsafe { shim_PSA_KEY_TYPE_DH_PUBLIC_KEY(group) }
+    unsafe { psa_crypto_binding::shim_PSA_KEY_TYPE_DH_PUBLIC_KEY(group) }
 }

--- a/psa-crypto/Cargo.toml
+++ b/psa-crypto/Cargo.toml
@@ -14,6 +14,10 @@ license = "Apache-2.0"
 repository = "https://github.com/parallaxsecond/rust-psa-crypto"
 
 [dependencies]
-psa-crypto-sys = { path = "../psa-crypto-sys" }
+psa-crypto-sys = { path = "../psa-crypto-sys", optional = true }
 log = "0.4.8"
 serde = { version = "1.0.110", features = ["derive"] }
+
+[features]
+default = ["with-mbed-crypto"]
+with-mbed-crypto = ["psa-crypto-sys"]

--- a/psa-crypto/README.md
+++ b/psa-crypto/README.md
@@ -1,3 +1,13 @@
 # PSA Cryptography API Rust Wrapper
 
 This is the higher-level, more Rust-friendly interface.
+
+## Mbed Crypto backing
+
+The `psa-crypto` comes by default with Mbed Crypto backing for
+the interface exposed. If the functionality of the library is
+not important/relevant, the interface type system (that offers
+functionality for identifying cryptographic algorithms and
+modelling key metadata) can be used independently by disabling
+the default features of the crate. The feature adding the Mbed
+Crypto support is `with-mbed-crypto`.

--- a/psa-crypto/src/lib.rs
+++ b/psa-crypto/src/lib.rs
@@ -39,12 +39,16 @@
 // This one is hard to avoid.
 #![allow(clippy::multiple_crate_versions)]
 
+#[cfg(feature = "with-mbed-crypto")]
 pub mod operations;
 pub mod types;
 
+#[cfg(feature = "with-mbed-crypto")]
 use core::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "with-mbed-crypto")]
 use types::status::{Error, Result, Status};
 
+#[cfg(feature = "with-mbed-crypto")]
 static INITIALISED: AtomicBool = AtomicBool::new(false);
 
 /// Initialize the PSA Crypto library
@@ -52,6 +56,7 @@ static INITIALISED: AtomicBool = AtomicBool::new(false);
 /// Applications must call this function before calling any other function in crate.
 /// Applications are permitted to call this function more than once. Once a call succeeds,
 /// subsequent calls are guaranteed to succeed.
+#[cfg(feature = "with-mbed-crypto")]
 pub fn init() -> Result<()> {
     // It it not a problem to call psa_crypto_init more than once.
     Status::from(unsafe { psa_crypto_sys::psa_crypto_init() }).to_result()?;
@@ -61,6 +66,7 @@ pub fn init() -> Result<()> {
 }
 
 /// Check if the PSA Crypto library has been initialized
+#[cfg(feature = "with-mbed-crypto")]
 pub fn initialized() -> Result<()> {
     if INITIALISED.load(Ordering::Relaxed) {
         Ok(())

--- a/psa-crypto/src/types/algorithm.rs
+++ b/psa-crypto/src/types/algorithm.rs
@@ -5,8 +5,11 @@
 
 #![allow(deprecated)]
 
+#[cfg(feature = "with-mbed-crypto")]
 use crate::types::status::{Error, Result};
+#[cfg(feature = "with-mbed-crypto")]
 use core::convert::{TryFrom, TryInto};
+#[cfg(feature = "with-mbed-crypto")]
 use log::error;
 use serde::{Deserialize, Serialize};
 
@@ -499,6 +502,7 @@ impl From<KeyDerivation> for Algorithm {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl TryFrom<psa_crypto_sys::psa_algorithm_t> for Algorithm {
     type Error = Error;
     fn try_from(alg: psa_crypto_sys::psa_algorithm_t) -> Result<Self> {
@@ -535,6 +539,7 @@ impl TryFrom<psa_crypto_sys::psa_algorithm_t> for Algorithm {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl TryFrom<Algorithm> for psa_crypto_sys::psa_algorithm_t {
     type Error = Error;
     fn try_from(alg: Algorithm) -> Result<Self> {
@@ -550,6 +555,7 @@ impl TryFrom<Algorithm> for psa_crypto_sys::psa_algorithm_t {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl TryFrom<psa_crypto_sys::psa_algorithm_t> for Hash {
     type Error = Error;
     fn try_from(alg: psa_crypto_sys::psa_algorithm_t) -> Result<Self> {
@@ -577,6 +583,7 @@ impl TryFrom<psa_crypto_sys::psa_algorithm_t> for Hash {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl From<Hash> for psa_crypto_sys::psa_algorithm_t {
     fn from(hash: Hash) -> Self {
         match hash {
@@ -599,6 +606,7 @@ impl From<Hash> for psa_crypto_sys::psa_algorithm_t {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl TryFrom<psa_crypto_sys::psa_algorithm_t> for SignHash {
     type Error = Error;
     fn try_from(alg: psa_crypto_sys::psa_algorithm_t) -> Result<Self> {
@@ -610,6 +618,7 @@ impl TryFrom<psa_crypto_sys::psa_algorithm_t> for SignHash {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl From<SignHash> for psa_crypto_sys::psa_algorithm_t {
     fn from(sign_hash: SignHash) -> Self {
         match sign_hash {
@@ -619,6 +628,7 @@ impl From<SignHash> for psa_crypto_sys::psa_algorithm_t {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl TryFrom<psa_crypto_sys::psa_algorithm_t> for AsymmetricSignature {
     type Error = Error;
     fn try_from(alg: psa_crypto_sys::psa_algorithm_t) -> Result<Self> {
@@ -652,6 +662,7 @@ impl TryFrom<psa_crypto_sys::psa_algorithm_t> for AsymmetricSignature {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl From<AsymmetricSignature> for psa_crypto_sys::psa_algorithm_t {
     fn from(asym_sign: AsymmetricSignature) -> Self {
         match asym_sign {

--- a/psa-crypto/src/types/key.rs
+++ b/psa-crypto/src/types/key.rs
@@ -6,7 +6,10 @@
 #![allow(deprecated)]
 
 use crate::types::algorithm::{Algorithm, Cipher};
-use crate::types::status::{Error, Result, Status};
+#[cfg(feature = "with-mbed-crypto")]
+use crate::types::status::Status;
+use crate::types::status::{Error, Result};
+#[cfg(feature = "with-mbed-crypto")]
 use core::convert::{TryFrom, TryInto};
 use log::error;
 use serde::{Deserialize, Serialize};
@@ -177,6 +180,7 @@ impl Attributes {
         }
     }
 
+    #[cfg(feature = "with-mbed-crypto")]
     pub(crate) fn reset(attributes: &mut psa_crypto_sys::psa_key_attributes_t) {
         unsafe { psa_crypto_sys::psa_reset_key_attributes(attributes) };
     }
@@ -387,12 +391,14 @@ pub struct UsageFlags {
 }
 
 /// Definition of the key ID.
+#[cfg(feature = "with-mbed-crypto")]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Id {
     pub(crate) id: psa_crypto_sys::psa_key_id_t,
     pub(crate) handle: Option<psa_crypto_sys::psa_key_handle_t>,
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl Id {
     pub(crate) fn handle(self) -> Result<psa_crypto_sys::psa_key_handle_t> {
         Ok(match self.handle {
@@ -416,6 +422,7 @@ impl Id {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl Id {
     /// Create a new Id from a persistent key ID
     pub fn from_persistent_key_id(id: u32) -> Self {
@@ -423,6 +430,7 @@ impl Id {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl TryFrom<Attributes> for psa_crypto_sys::psa_key_attributes_t {
     type Error = Error;
     fn try_from(attributes: Attributes) -> Result<Self> {
@@ -447,6 +455,7 @@ impl TryFrom<Attributes> for psa_crypto_sys::psa_key_attributes_t {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl TryFrom<psa_crypto_sys::psa_key_attributes_t> for Attributes {
     type Error = Error;
     fn try_from(attributes: psa_crypto_sys::psa_key_attributes_t) -> Result<Self> {
@@ -464,6 +473,7 @@ impl TryFrom<psa_crypto_sys::psa_key_attributes_t> for Attributes {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl From<Lifetime> for psa_crypto_sys::psa_key_lifetime_t {
     fn from(lifetime: Lifetime) -> Self {
         match lifetime {
@@ -474,6 +484,7 @@ impl From<Lifetime> for psa_crypto_sys::psa_key_lifetime_t {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl From<psa_crypto_sys::psa_key_lifetime_t> for Lifetime {
     fn from(lifetime: psa_crypto_sys::psa_key_lifetime_t) -> Self {
         match lifetime {
@@ -484,6 +495,7 @@ impl From<psa_crypto_sys::psa_key_lifetime_t> for Lifetime {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl From<UsageFlags> for psa_crypto_sys::psa_key_usage_t {
     fn from(flags: UsageFlags) -> Self {
         let mut usage_flags = 0;
@@ -509,6 +521,7 @@ impl From<UsageFlags> for psa_crypto_sys::psa_key_usage_t {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl From<psa_crypto_sys::psa_key_usage_t> for UsageFlags {
     fn from(flags: psa_crypto_sys::psa_key_usage_t) -> Self {
         UsageFlags {
@@ -526,6 +539,7 @@ impl From<psa_crypto_sys::psa_key_usage_t> for UsageFlags {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl TryFrom<EccFamily> for psa_crypto_sys::psa_ecc_curve_t {
     type Error = Error;
     fn try_from(family: EccFamily) -> Result<Self> {
@@ -543,6 +557,7 @@ impl TryFrom<EccFamily> for psa_crypto_sys::psa_ecc_curve_t {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl TryFrom<psa_crypto_sys::psa_ecc_curve_t> for EccFamily {
     type Error = Error;
     fn try_from(family: psa_crypto_sys::psa_ecc_curve_t) -> Result<Self> {
@@ -563,6 +578,7 @@ impl TryFrom<psa_crypto_sys::psa_ecc_curve_t> for EccFamily {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl From<DhFamily> for psa_crypto_sys::psa_dh_group_t {
     fn from(group: DhFamily) -> Self {
         match group {
@@ -571,6 +587,7 @@ impl From<DhFamily> for psa_crypto_sys::psa_dh_group_t {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl TryFrom<psa_crypto_sys::psa_dh_group_t> for DhFamily {
     type Error = Error;
     fn try_from(group: psa_crypto_sys::psa_dh_group_t) -> Result<Self> {
@@ -584,6 +601,7 @@ impl TryFrom<psa_crypto_sys::psa_dh_group_t> for DhFamily {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl TryFrom<Type> for psa_crypto_sys::psa_key_type_t {
     type Error = Error;
     fn try_from(key_type: Type) -> Result<Self> {
@@ -614,6 +632,7 @@ impl TryFrom<Type> for psa_crypto_sys::psa_key_type_t {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl TryFrom<psa_crypto_sys::psa_key_type_t> for Type {
     type Error = Error;
     fn try_from(key_type: psa_crypto_sys::psa_key_type_t) -> Result<Self> {

--- a/psa-crypto/src/types/status.rs
+++ b/psa-crypto/src/types/status.rs
@@ -5,6 +5,7 @@
 //!
 //! This module defines success and error codes returned by any PSA function.
 
+#[cfg(feature = "with-mbed-crypto")]
 use log::error;
 
 /// Result type returned by any PSA operation
@@ -82,6 +83,7 @@ impl From<Error> for Status {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl From<psa_crypto_sys::psa_status_t> for Status {
     fn from(status: psa_crypto_sys::psa_status_t) -> Self {
         match status {
@@ -112,6 +114,7 @@ impl From<psa_crypto_sys::psa_status_t> for Status {
     }
 }
 
+#[cfg(feature = "with-mbed-crypto")]
 impl From<Status> for psa_crypto_sys::psa_status_t {
     fn from(status: Status) -> psa_crypto_sys::psa_status_t {
         match status {


### PR DESCRIPTION
This commit adds a feature to the `psa-crypto` crate to allow it to be
built without a library backing its API - this leaves only the type
system in place, with none of the callable methods.
The bindgen exports of `psa-crypto-sys` are also restricted to those
strictly necessary to the `psa-crypto` crate.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>