### PR TITLE
Improve build of psa-crypto-sys crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The software is provided under Apache-2.0. Contributions to this project are acc
 This project uses the following third party crates:
 
 * bingden (BSD-3-Clause)
+* cmake (MIT and Apache-2.0)
 * cc (MIT and Apache-2.0)
 * log (MIT and Apache-2.0)
 * serde (MIT and Apache-2.0)

--- a/psa-crypto-sys/Cargo.toml
+++ b/psa-crypto-sys/Cargo.toml
@@ -17,6 +17,7 @@ links = "mbedcrypto"
 [build-dependencies]
 bindgen = "0.50.0"
 cc = "1.0.54"
+cmake = "0.1.44"
 
 [features]
 static = []


### PR DESCRIPTION
This commit improves on the build mechanism for the sys crate. It moves
all temporary build material into OUT_DIR, including the mbedtls
config.h file and the build products of the library.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>