### PR TITLE
Add Secure Element types definition

### DIFF
--- a/psa-crypto-sys/src/c/shim.h
+++ b/psa-crypto-sys/src/c/shim.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <psa/crypto.h>
+#include <psa/crypto_se_driver.h>
 
 const psa_status_t shim_PSA_SUCCESS = PSA_SUCCESS;
 const psa_status_t shim_PSA_ERROR_GENERIC_ERROR = PSA_ERROR_GENERIC_ERROR;

--- a/psa-crypto-sys/src/constants.rs
+++ b/psa-crypto-sys/src/constants.rs
@@ -7,10 +7,6 @@
 
 use super::psa_crypto_binding::*;
 
-// xx There are not part of the public PSA API and should be removed:
-pub const PSA_KEY_SLOT_COUNT: isize = 32;
-pub const PSA_MAX_PERSISTENT_KEY_IDENTIFIER: psa_key_id_t = 0x3fff_ffff;
-
 // PSA error codes
 pub const PSA_SUCCESS: psa_status_t = shim_PSA_SUCCESS;
 pub const PSA_ERROR_GENERIC_ERROR: psa_status_t = shim_PSA_ERROR_GENERIC_ERROR;

--- a/psa-crypto-sys/src/lib.rs
+++ b/psa-crypto-sys/src/lib.rs
@@ -50,6 +50,14 @@ pub use psa_crypto_binding::psa_sign_hash;
 pub use psa_crypto_binding::psa_status_t;
 pub use psa_crypto_binding::psa_verify_hash;
 
+// Secure Element Driver definitions
+pub use psa_crypto_binding::psa_drv_se_asymmetric_t;
+pub use psa_crypto_binding::psa_drv_se_context_t;
+pub use psa_crypto_binding::psa_drv_se_key_management_t;
+pub use psa_crypto_binding::psa_drv_se_t;
+pub use psa_crypto_binding::psa_key_slot_number_t;
+pub use psa_crypto_binding::PSA_DRV_SE_HAL_VERSION;
+
 pub unsafe fn psa_get_key_bits(attributes: *const psa_key_attributes_t) -> usize {
     psa_crypto_binding::shim_get_key_bits(attributes)
 }


### PR DESCRIPTION
This allows this crate to be used to create a Rust Secure Element
driver.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>