### PR TITLE
Add various improvements

### DIFF
--- a/psa-crypto-sys/Cargo.toml
+++ b/psa-crypto-sys/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/parallaxsecond/rust-psa-crypto"
 links = "mbedcrypto"
 
 [build-dependencies]
-bindgen = "0.50.0"
+bindgen = "0.54.0"
 cc = "1.0.54"
 cmake = "0.1.44"
 

--- a/psa-crypto-sys/README.md
+++ b/psa-crypto-sys/README.md
@@ -10,11 +10,11 @@ links to libraries that expose this interface. The expected name
 of the library is derived from the reference implementation of the
 API - `mbedcrypto`.
 
-If the library and its headers folder are already installed locally you
-can specify their location using the `MBEDTLS_LIB_DIR` and `MBEDTLS_INCLUDE_DIR`
-environment variables at build time. By default dynamic linking is
-attempted - if you wish to link statically you can enable the `static`
-feature.
+If the library and its headers folder are already installed locally you can
+specify their location (the full absolute path) using the `MBEDTLS_LIB_DIR` and
+`MBEDTLS_INCLUDE_DIR` environment variables at build time. By default dynamic
+linking is attempted - if you wish to link statically you can enable the
+`static` feature.
 
 Alternatively, the crate will attempt to build the library from scratch and
 link against it statically. In this use case enabling the `static` feature

--- a/psa-crypto-sys/src/c/shim.c
+++ b/psa-crypto-sys/src/c/shim.c
@@ -7,6 +7,12 @@
 
 #include "shim.h"
 
+psa_key_id_t
+shim_get_key_id(const psa_key_attributes_t *attributes)
+{
+    return psa_get_key_id(attributes);
+}
+
 size_t
 shim_get_key_bits(const psa_key_attributes_t *attributes)
 {

--- a/psa-crypto-sys/src/c/shim.h
+++ b/psa-crypto-sys/src/c/shim.h
@@ -126,6 +126,9 @@ const psa_key_usage_t shim_PSA_KEY_USAGE_SIGN = PSA_KEY_USAGE_SIGN;
 const psa_key_usage_t shim_PSA_KEY_USAGE_VERIFY = PSA_KEY_USAGE_VERIFY;
 const psa_key_usage_t shim_PSA_KEY_USAGE_DERIVE = PSA_KEY_USAGE_DERIVE;
 
+psa_key_id_t
+shim_get_key_id(const psa_key_attributes_t *attributes);
+
 size_t
 shim_get_key_bits(const psa_key_attributes_t *attributes);
 

--- a/psa-crypto-sys/src/lib.rs
+++ b/psa-crypto-sys/src/lib.rs
@@ -55,8 +55,13 @@ pub use psa_crypto_binding::psa_drv_se_asymmetric_t;
 pub use psa_crypto_binding::psa_drv_se_context_t;
 pub use psa_crypto_binding::psa_drv_se_key_management_t;
 pub use psa_crypto_binding::psa_drv_se_t;
+pub use psa_crypto_binding::psa_key_creation_method_t;
 pub use psa_crypto_binding::psa_key_slot_number_t;
 pub use psa_crypto_binding::PSA_DRV_SE_HAL_VERSION;
+
+pub unsafe fn psa_get_key_id(attributes: *const psa_key_attributes_t) -> psa_key_id_t {
+    psa_crypto_binding::shim_get_key_id(attributes)
+}
 
 pub unsafe fn psa_get_key_bits(attributes: *const psa_key_attributes_t) -> usize {
     psa_crypto_binding::shim_get_key_bits(attributes)

--- a/psa-crypto/src/lib.rs
+++ b/psa-crypto/src/lib.rs
@@ -46,6 +46,9 @@ pub mod operations;
 pub mod types;
 
 #[cfg(feature = "with-mbed-crypto")]
+pub use psa_crypto_sys as ffi;
+
+#[cfg(feature = "with-mbed-crypto")]
 use core::sync::atomic::{AtomicBool, Ordering};
 #[cfg(feature = "with-mbed-crypto")]
 use types::status::{Error, Result, Status};

--- a/psa-crypto/src/types/status.rs
+++ b/psa-crypto/src/types/status.rs
@@ -131,33 +131,40 @@ impl From<Status> for psa_crypto_sys::psa_status_t {
     fn from(status: Status) -> psa_crypto_sys::psa_status_t {
         match status {
             Status::Success => psa_crypto_sys::PSA_SUCCESS,
-            Status::Error(error) => match error {
-                Error::GenericError => psa_crypto_sys::PSA_ERROR_GENERIC_ERROR,
-                Error::NotSupported => psa_crypto_sys::PSA_ERROR_NOT_SUPPORTED,
-                Error::NotPermitted => psa_crypto_sys::PSA_ERROR_NOT_PERMITTED,
-                Error::BufferTooSmall => psa_crypto_sys::PSA_ERROR_BUFFER_TOO_SMALL,
-                Error::AlreadyExists => psa_crypto_sys::PSA_ERROR_ALREADY_EXISTS,
-                Error::DoesNotExist => psa_crypto_sys::PSA_ERROR_DOES_NOT_EXIST,
-                Error::BadState => psa_crypto_sys::PSA_ERROR_BAD_STATE,
-                Error::InvalidArgument => psa_crypto_sys::PSA_ERROR_INVALID_ARGUMENT,
-                Error::InsufficientMemory => psa_crypto_sys::PSA_ERROR_INSUFFICIENT_MEMORY,
-                Error::InsufficientStorage => psa_crypto_sys::PSA_ERROR_INSUFFICIENT_STORAGE,
-                Error::CommunicationFailure => psa_crypto_sys::PSA_ERROR_COMMUNICATION_FAILURE,
-                Error::StorageFailure => psa_crypto_sys::PSA_ERROR_STORAGE_FAILURE,
-                //Error::DataCorrupt => psa_crypto_sys::PSA_ERROR_DATA_CORRUPT,
-                //Error::DataInvalid => psa_crypto_sys::PSA_ERROR_DATA_INVALID,
-                Error::HardwareFailure => psa_crypto_sys::PSA_ERROR_HARDWARE_FAILURE,
-                //Error::CorruptionDetected => psa_crypto_sys::PSA_ERROR_CORRUPTION_DETECTED,
-                Error::InsufficientEntropy => psa_crypto_sys::PSA_ERROR_INSUFFICIENT_ENTROPY,
-                Error::InvalidSignature => psa_crypto_sys::PSA_ERROR_INVALID_SIGNATURE,
-                Error::InvalidPadding => psa_crypto_sys::PSA_ERROR_INVALID_PADDING,
-                Error::InsufficientData => psa_crypto_sys::PSA_ERROR_INSUFFICIENT_DATA,
-                Error::InvalidHandle => psa_crypto_sys::PSA_ERROR_INVALID_HANDLE,
-                e => {
-                    error!("No equivalent of {:?} to a psa_status_t.", e);
-                    psa_crypto_sys::PSA_ERROR_GENERIC_ERROR
-                }
-            },
+            Status::Error(error) => error.into(),
+        }
+    }
+}
+
+#[cfg(feature = "with-mbed-crypto")]
+impl From<Error> for psa_crypto_sys::psa_status_t {
+    fn from(error: Error) -> psa_crypto_sys::psa_status_t {
+        match error {
+            Error::GenericError => psa_crypto_sys::PSA_ERROR_GENERIC_ERROR,
+            Error::NotSupported => psa_crypto_sys::PSA_ERROR_NOT_SUPPORTED,
+            Error::NotPermitted => psa_crypto_sys::PSA_ERROR_NOT_PERMITTED,
+            Error::BufferTooSmall => psa_crypto_sys::PSA_ERROR_BUFFER_TOO_SMALL,
+            Error::AlreadyExists => psa_crypto_sys::PSA_ERROR_ALREADY_EXISTS,
+            Error::DoesNotExist => psa_crypto_sys::PSA_ERROR_DOES_NOT_EXIST,
+            Error::BadState => psa_crypto_sys::PSA_ERROR_BAD_STATE,
+            Error::InvalidArgument => psa_crypto_sys::PSA_ERROR_INVALID_ARGUMENT,
+            Error::InsufficientMemory => psa_crypto_sys::PSA_ERROR_INSUFFICIENT_MEMORY,
+            Error::InsufficientStorage => psa_crypto_sys::PSA_ERROR_INSUFFICIENT_STORAGE,
+            Error::CommunicationFailure => psa_crypto_sys::PSA_ERROR_COMMUNICATION_FAILURE,
+            Error::StorageFailure => psa_crypto_sys::PSA_ERROR_STORAGE_FAILURE,
+            //Error::DataCorrupt => psa_crypto_sys::PSA_ERROR_DATA_CORRUPT,
+            //Error::DataInvalid => psa_crypto_sys::PSA_ERROR_DATA_INVALID,
+            Error::HardwareFailure => psa_crypto_sys::PSA_ERROR_HARDWARE_FAILURE,
+            //Error::CorruptionDetected => psa_crypto_sys::PSA_ERROR_CORRUPTION_DETECTED,
+            Error::InsufficientEntropy => psa_crypto_sys::PSA_ERROR_INSUFFICIENT_ENTROPY,
+            Error::InvalidSignature => psa_crypto_sys::PSA_ERROR_INVALID_SIGNATURE,
+            Error::InvalidPadding => psa_crypto_sys::PSA_ERROR_INVALID_PADDING,
+            Error::InsufficientData => psa_crypto_sys::PSA_ERROR_INSUFFICIENT_DATA,
+            Error::InvalidHandle => psa_crypto_sys::PSA_ERROR_INVALID_HANDLE,
+            e => {
+                error!("No equivalent of {:?} to a psa_status_t.", e);
+                psa_crypto_sys::PSA_ERROR_GENERIC_ERROR
+            }
         }
     }
 }


### PR DESCRIPTION
This commit:
* fixes a bug in build.rs where the shim library was not compiled when
dynamically linking
* add the psa_get_key_id function to the shim
* allow to access psa-crypto-sys from psa-crypto if compiling with Mbed
Crypto
* add a conversion from Error to psa_status_t to avoid going to Status

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>