### PR TITLE
Modify Mbed TLS version to most recent realease

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -46,3 +46,15 @@ pushd psa-crypto
 cargo build --no-default-features
 cargo build --no-default-features --features with-mbed-crypto
 cargo build --no-default-features --features no-std
+
+# Test dynamic linking
+git clone https://github.com/ARMmbed/mbedtls.git
+pushd mbedtls
+git checkout mbedtls-2.22.0
+./scripts/config.py crypto
+SHARED=1 make
+popd
+
+# Build the driver, clean before to force dynamic linking
+cargo clean
+MBEDTLS_LIB_DIR=$(pwd)/mbedtls/library MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release

--- a/psa-crypto-sys/README.md
+++ b/psa-crypto-sys/README.md
@@ -27,6 +27,4 @@ Linking and generating implementation-specific APIs is controlled by the
 require only the spec-defined bits of the API (namely the constants and types)
 you can simply disable default features.
 
-Currently the version of MbedTLS built is based on the `development` branch
-of their repository, as the Mbed Crypto functionality has not yet been included in
-a standard release.
+Currently the version of MbedTLS built is 2.22.0

--- a/psa-crypto-sys/src/lib.rs
+++ b/psa-crypto-sys/src/lib.rs
@@ -48,7 +48,7 @@ pub use psa_crypto_binding::{
 #[cfg(feature = "implementation-defined")]
 pub use psa_crypto_binding::{
     psa_drv_se_asymmetric_t, psa_drv_se_context_t, psa_drv_se_key_management_t, psa_drv_se_t,
-    psa_key_creation_method_t, psa_key_location_t, psa_key_persistence_t, psa_key_slot_number_t,
+    psa_key_creation_method_t, psa_key_slot_number_t,
 };
 
 #[cfg(feature = "implementation-defined")]


### PR DESCRIPTION
Last release of Mbed TLS included Nbed Crypto so we use that instead of
a commit number.
Also adds tests for dynamic linking on the CI.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>