### PR TITLE
Derive Zeroize for all types

### DIFF
--- a/psa-crypto/Cargo.toml
+++ b/psa-crypto/Cargo.toml
@@ -17,6 +17,7 @@ repository = "https://github.com/parallaxsecond/rust-psa-crypto"
 psa-crypto-sys = { path = "../psa-crypto-sys", version = "0.2.0", default-features = false }
 log = "0.4.8"
 serde = { version = "1.0.110", features = ["derive"] }
+zeroize = { version = "1.1.0", features = ["zeroize_derive"] }
 
 [features]
 default = ["with-mbed-crypto", "no-std"]

--- a/psa-crypto/src/types/algorithm.rs
+++ b/psa-crypto/src/types/algorithm.rs
@@ -12,11 +12,12 @@ use core::convert::{TryFrom, TryInto};
 #[cfg(feature = "with-mbed-crypto")]
 use log::error;
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 /// Enumeration of possible algorithm definitions.
 /// Each variant of the enum contains a main algorithm type (which is required for
 /// that variant).
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum Algorithm {
     /// An invalid algorithm identifier value.
     /// `None` does not allow any cryptographic operation with the key. The key can still be
@@ -62,7 +63,7 @@ impl Algorithm {
 }
 
 /// Enumeration of hash algorithms supported.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 #[allow(deprecated)]
 pub enum Hash {
     /// MD2
@@ -124,7 +125,7 @@ impl Hash {
 }
 
 /// Enumeration of untruncated MAC algorithms.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum FullLengthMac {
     /// HMAC algorithm
     Hmac {
@@ -138,7 +139,7 @@ pub enum FullLengthMac {
 }
 
 /// Enumeration of message authentication code algorithms supported.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum Mac {
     /// Untruncated MAC algorithm
     FullLength(FullLengthMac),
@@ -183,7 +184,7 @@ impl Mac {
 }
 
 /// Enumeration of symmetric encryption algorithms supported.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 // StreamCipher contains "Cipher" to differentiate with the other ones that are block cipher modes.
 #[allow(clippy::pub_enum_variant_names)]
 pub enum Cipher {
@@ -221,7 +222,7 @@ impl Cipher {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 /// AEAD algorithm with default length tag enumeration
 pub enum AeadWithDefaultLengthTag {
     /// The CCM authenticated encryption algorithm.
@@ -234,7 +235,7 @@ pub enum AeadWithDefaultLengthTag {
 
 /// Enumeration of authenticated encryption with additional data algorithms
 /// supported.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum Aead {
     /// AEAD algorithm with a default length tag
     AeadWithDefaultLengthTag(AeadWithDefaultLengthTag),
@@ -279,7 +280,7 @@ impl Aead {
 }
 
 /// Enumeration of hash algorithms used in "hash-and-sign" algorithms.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum SignHash {
     /// A specific hash algorithm to choose.
     Specific(Hash),
@@ -313,7 +314,7 @@ impl From<Hash> for SignHash {
 }
 
 /// Enumeration of asymmetric signing algorithms supported.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum AsymmetricSignature {
     /// RSA PKCS#1 v1.5 signature with hashing.
     RsaPkcs1v15Sign {
@@ -442,7 +443,7 @@ impl AsymmetricSignature {
 }
 
 /// Enumeration of asymmetric encryption algorithms supported.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum AsymmetricEncryption {
     /// RSA PKCS#1 v1.5 encryption.
     RsaPkcs1v15Crypt,
@@ -454,7 +455,7 @@ pub enum AsymmetricEncryption {
 }
 
 /// Key agreement algorithm enumeration.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum RawKeyAgreement {
     /// The finite-field Diffie-Hellman (DH) key agreement algorithm.
     Ffdh,
@@ -463,7 +464,7 @@ pub enum RawKeyAgreement {
 }
 
 /// Enumeration of key agreement algorithms supported.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum KeyAgreement {
     /// Key agreement only algorithm.
     Raw(RawKeyAgreement),
@@ -477,7 +478,7 @@ pub enum KeyAgreement {
 }
 
 /// Enumeration of key derivation functions supported.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum KeyDerivation {
     /// HKDF algorithm.
     Hkdf {

--- a/psa-crypto/src/types/key.rs
+++ b/psa-crypto/src/types/key.rs
@@ -17,10 +17,11 @@ use core::convert::{TryFrom, TryInto};
 use log::error;
 pub use psa_crypto_sys::{self, psa_key_id_t, PSA_KEY_ID_USER_MAX, PSA_KEY_ID_USER_MIN};
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 /// Native definition of the attributes needed to fully describe
 /// a cryptographic key.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub struct Attributes {
     /// Lifetime of the key
     pub lifetime: Lifetime,
@@ -355,7 +356,7 @@ impl Attributes {
 
 /// The lifetime of a key indicates where it is stored and which application and system actions
 /// will create and destroy it.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum Lifetime {
     /// A volatile key only exists as long as the identifier to it is not destroyed.
     Volatile,
@@ -368,7 +369,7 @@ pub enum Lifetime {
 }
 
 /// Enumeration of key types supported.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum Type {
     /// Not a valid key type for any cryptographic operation but can be used to store arbitrary
     /// data in the key store.
@@ -479,7 +480,7 @@ impl Type {
 /// Enumeration of elliptic curve families supported. They are needed to create an ECC key.
 /// The specific curve used for each family is given by the `bits` field of the key attributes.
 /// See the book for more details.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum EccFamily {
     /// SEC Koblitz curves over prime fields.
     /// This family comprises the following curves:
@@ -544,7 +545,7 @@ pub enum EccFamily {
 }
 
 /// Enumeration of Diffie Hellman group families supported.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub enum DhFamily {
     /// Diffie-Hellman groups defined in RFC 7919 Appendix A.
     /// This family includes groups with the following `bits`: 2048, 3072, 4096, 6144, 8192.
@@ -553,7 +554,7 @@ pub enum DhFamily {
 }
 
 /// Definition of the key policy, what is permitted to do with the key.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub struct Policy {
     /// Usage flags for the key.
     pub usage_flags: UsageFlags,
@@ -562,7 +563,7 @@ pub struct Policy {
 }
 
 /// Definition of the usage flags. They encode what kind of operations are permitted on the key.
-#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize, Zeroize)]
 pub struct UsageFlags {
     /// Permission to export the key.
     pub export: bool,
@@ -588,7 +589,7 @@ pub struct UsageFlags {
 
 /// Definition of the key ID.
 #[cfg(feature = "with-mbed-crypto")]
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub struct Id {
     pub(crate) id: psa_key_id_t,
     pub(crate) handle: Option<psa_crypto_sys::psa_key_handle_t>,

--- a/psa-crypto/src/types/status.rs
+++ b/psa-crypto/src/types/status.rs
@@ -6,6 +6,7 @@
 //! This module defines success and error codes returned by any PSA function.
 
 use log::error;
+use zeroize::Zeroize;
 
 #[cfg(not(feature = "no-std"))]
 use std::fmt;
@@ -14,7 +15,7 @@ use std::fmt;
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Definition of a PSA status code
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Zeroize)]
 pub enum Status {
     /// Status code for success
     Success,
@@ -45,7 +46,7 @@ impl Status {
 }
 
 /// Definition of a PSA status code
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Zeroize)]
 pub enum Error {
     /// An error occurred that does not correspond to any defined failure cause
     GenericError,


### PR DESCRIPTION
This commit adds derivation of `Zeroize` for all types defined in the
`psa-crypto` crate.

Signed-off-by: Ionut Mihalcea <ionut.mihalcea@arm.com>