### PR TITLE
Add an env var for static linking to Mbed Crypto

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -60,3 +60,7 @@ popd
 # Build the driver, clean before to force dynamic linking
 cargo clean
 MBEDTLS_LIB_DIR=$(pwd)/mbedtls/library MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release
+
+# Build the driver, clean before to force static linking
+cargo clean
+MBEDTLS_LIB_DIR=$(pwd)/mbedtls/library MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include MBEDCRYPTO_STATIC=1 cargo build --release

--- a/psa-crypto-sys/README.md
+++ b/psa-crypto-sys/README.md
@@ -21,7 +21,8 @@ If the library and its headers folder are already installed locally you can
 specify their location (the full absolute path) using the `MBEDTLS_LIB_DIR` and
 `MBEDTLS_INCLUDE_DIR` environment variables at build time. By default dynamic
 linking is attempted - if you wish to link statically you can enable the
-`static` feature.
+`static` feature or pass the `MBEDCRYPTO_STATIC` environment variable, set to
+any value.
 
 Alternatively, the crate will attempt to build the library from scratch and
 link against it statically. In this use case enabling the `static` feature

--- a/psa-crypto-sys/build.rs
+++ b/psa-crypto-sys/build.rs
@@ -131,7 +131,7 @@ fn main() -> Result<()> {
     {
         lib = lib_dir;
         include = include_dir;
-        statically = cfg!(feature = "static");
+        statically = cfg!(feature = "static") || env::var("MBEDCRYPTO_STATIC").is_ok();
     } else {
         println!("Did not find environment variables, building MbedTLS!");
         let mut mbed_lib_dir = compile_mbed_crypto()?;


### PR DESCRIPTION
This is useful when this crate is used deep in the dependency tree.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>