### PR TITLE
Add an interface feature only using include files

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -46,7 +46,7 @@ cargo build --no-default-features
 popd
 pushd psa-crypto
 cargo build --no-default-features
-cargo build --no-default-features --features with-mbed-crypto
+cargo build --no-default-features --features operations
 cargo build --no-default-features --features no-std
 
 # Test dynamic linking
@@ -57,10 +57,14 @@ git checkout mbedtls-2.22.0
 SHARED=1 make
 popd
 
-# Build the driver, clean before to force dynamic linking
+# Clean before to force dynamic linking
 cargo clean
 MBEDTLS_LIB_DIR=$(pwd)/mbedtls/library MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release
 
-# Build the driver, clean before to force static linking
+# Clean before to force static linking
 cargo clean
 MBEDTLS_LIB_DIR=$(pwd)/mbedtls/library MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include MBEDCRYPTO_STATIC=1 cargo build --release
+
+# Clean before to only build the interface
+cargo clean
+MBEDTLS_INCLUDE_DIR=$(pwd)/mbedtls/include cargo build --release

--- a/psa-crypto-sys/Cargo.toml
+++ b/psa-crypto-sys/Cargo.toml
@@ -20,6 +20,7 @@ cc = "1.0.54"
 cmake = "0.1.44"
 
 [features]
-default = ["implementation-defined"]
+default = ["operations"]
 static = []
-implementation-defined = []
+interface = []
+operations = ["interface"]

--- a/psa-crypto-sys/README.md
+++ b/psa-crypto-sys/README.md
@@ -31,8 +31,12 @@ requirements for configuring and building MbedTLS can be found
 [on their repository homepage](https://github.com/ARMmbed/mbedtls#tool-versions).
 
 Linking and generating implementation-specific APIs is controlled by the
-`implementation-defined` feature that is enabled by default. Therefore, if you
-require only the spec-defined bits of the API (namely the constants and types)
+`operations` feature that is enabled by default. Therefore, if you
+require only the specification-defined bits of the API (namely the constants and types)
 you can simply disable default features.
 
-Currently the version of MbedTLS built is 2.22.0
+You might want to only use the interface part (including the
+implementation-defined bits) of this crate to build for example a PSA Secure
+Element Driver. With the feature `interface`, this crate will only produce the
+implementation-defined types and their helpers/accessors using the
+`MBEDTLS_INCLUDE_DIR` variable that you need to pass.

--- a/psa-crypto-sys/src/constants.rs
+++ b/psa-crypto-sys/src/constants.rs
@@ -92,6 +92,3 @@ pub const PSA_KEY_USAGE_VERIFY: psa_key_usage_t = 2048;
 pub const PSA_KEY_USAGE_DERIVE: psa_key_usage_t = 4096;
 pub const PSA_KEY_ID_USER_MIN: psa_key_id_t = 0x0000_0001;
 pub const PSA_KEY_ID_USER_MAX: psa_key_id_t = 0x3fff_ffff;
-
-#[cfg(feature = "implementation-defined")]
-pub const PSA_DRV_SE_HAL_VERSION: u32 = 5;

--- a/psa-crypto-sys/src/lib.rs
+++ b/psa-crypto-sys/src/lib.rs
@@ -21,7 +21,7 @@
     trivial_casts
 )]
 #[allow(clippy::all)]
-#[cfg(feature = "implementation-defined")]
+#[cfg(feature = "interface")]
 mod psa_crypto_binding {
     include!(concat!(env!("OUT_DIR"), "/shim_bindings.rs"));
 }
@@ -29,7 +29,7 @@ mod psa_crypto_binding {
 #[allow(dead_code)]
 mod constants;
 #[allow(dead_code)]
-#[cfg(feature = "implementation-defined")]
+#[cfg(feature = "interface")]
 mod shim_methods;
 #[allow(dead_code)]
 mod types;
@@ -37,20 +37,23 @@ mod types;
 pub use constants::*;
 pub use types::*;
 
-#[cfg(feature = "implementation-defined")]
+#[cfg(feature = "operations")]
 pub use psa_crypto_binding::{
     psa_asymmetric_decrypt, psa_asymmetric_encrypt, psa_close_key, psa_crypto_init,
     psa_destroy_key, psa_export_key, psa_export_public_key, psa_generate_key,
-    psa_get_key_attributes, psa_import_key, psa_key_attributes_t, psa_open_key,
-    psa_reset_key_attributes, psa_sign_hash, psa_verify_hash,
+    psa_get_key_attributes, psa_import_key, psa_open_key, psa_reset_key_attributes, psa_sign_hash,
+    psa_verify_hash,
 };
 
+#[cfg(feature = "interface")]
+pub use psa_crypto_binding::psa_key_attributes_t;
+
 // Secure Element Driver definitions
-#[cfg(feature = "implementation-defined")]
+#[cfg(feature = "interface")]
 pub use psa_crypto_binding::{
     psa_drv_se_asymmetric_t, psa_drv_se_context_t, psa_drv_se_key_management_t, psa_drv_se_t,
     psa_key_creation_method_t, psa_key_slot_number_t,
 };
 
-#[cfg(feature = "implementation-defined")]
+#[cfg(feature = "interface")]
 pub use shim_methods::*;

--- a/psa-crypto/Cargo.toml
+++ b/psa-crypto/Cargo.toml
@@ -25,6 +25,7 @@ rand = "0.7.3"
 base64 = "0.12.3"
 
 [features]
-default = ["with-mbed-crypto", "no-std"]
-with-mbed-crypto = ["psa-crypto-sys/implementation-defined"]
+default = ["operations", "no-std"]
+operations = ["psa-crypto-sys/operations", "interface"]
+interface = ["psa-crypto-sys/interface"]
 no-std = []

--- a/psa-crypto/README.md
+++ b/psa-crypto/README.md
@@ -11,10 +11,13 @@ This is the higher-level, more Rust-friendly interface.
 
 ## Mbed Crypto backing
 
-The `psa-crypto` comes by default with Mbed Crypto backing for
-the interface exposed. If the functionality of the library is
-not important/relevant, the interface type system (that offers
-functionality for identifying cryptographic algorithms and
-modelling key metadata) can be used independently by disabling
-the default features of the crate. The feature adding the Mbed
-Crypto support is `with-mbed-crypto`.
+The features of this crate can modify what is compiled in from the PSA Crypto
+specification:
+* `operations`: everything is included. The `psa-crypto-sys` crate statically
+  links by default Mbed Crypto. See the documentation of [that
+crate](https://github.com/parallaxsecond/rust-psa-crypto/tree/master/psa-crypto-sys)
+to see how to modify the linking options. This feature is activated by default.
+* `interface`: only the abstraction over the PSA Crypto interface (types,
+  helper methods) are included. The `MBEDTLS_INCLUDE_DIR` environment variable
+is needed to produce Rust shims around PSA Crypto macros.
+* without any of the above: only the specification-defined parts are included.

--- a/psa-crypto/src/lib.rs
+++ b/psa-crypto/src/lib.rs
@@ -41,19 +41,18 @@
 // This one is hard to avoid.
 #![allow(clippy::multiple_crate_versions)]
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "operations")]
 pub mod operations;
 pub mod types;
 
-#[cfg(feature = "with-mbed-crypto")]
 pub use psa_crypto_sys as ffi;
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "operations")]
 use core::sync::atomic::{AtomicBool, Ordering};
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "operations")]
 use types::status::{Error, Result, Status};
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "operations")]
 static INITIALISED: AtomicBool = AtomicBool::new(false);
 
 /// Initialize the PSA Crypto library
@@ -71,7 +70,7 @@ static INITIALISED: AtomicBool = AtomicBool::new(false);
 /// // Can be called twice
 /// init().unwrap();
 /// ```
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "operations")]
 pub fn init() -> Result<()> {
     // It is not a problem to call psa_crypto_init more than once.
     Status::from(unsafe { psa_crypto_sys::psa_crypto_init() }).to_result()?;
@@ -89,7 +88,7 @@ pub fn init() -> Result<()> {
 /// init().unwrap();
 /// initialized().unwrap();
 /// ```
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "operations")]
 pub fn initialized() -> Result<()> {
     if INITIALISED.load(Ordering::Relaxed) {
         Ok(())

--- a/psa-crypto/src/types/algorithm.rs
+++ b/psa-crypto/src/types/algorithm.rs
@@ -5,11 +5,11 @@
 
 #![allow(deprecated)]
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 use crate::types::status::{Error, Result};
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 use core::convert::{TryFrom, TryInto};
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 use log::error;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
@@ -538,7 +538,7 @@ impl From<KeyDerivation> for Algorithm {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<psa_crypto_sys::psa_algorithm_t> for Algorithm {
     type Error = Error;
     fn try_from(alg: psa_crypto_sys::psa_algorithm_t) -> Result<Self> {
@@ -575,7 +575,7 @@ impl TryFrom<psa_crypto_sys::psa_algorithm_t> for Algorithm {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<Algorithm> for psa_crypto_sys::psa_algorithm_t {
     type Error = Error;
     fn try_from(alg: Algorithm) -> Result<Self> {
@@ -592,7 +592,7 @@ impl TryFrom<Algorithm> for psa_crypto_sys::psa_algorithm_t {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<psa_crypto_sys::psa_algorithm_t> for Hash {
     type Error = Error;
     fn try_from(alg: psa_crypto_sys::psa_algorithm_t) -> Result<Self> {
@@ -620,7 +620,7 @@ impl TryFrom<psa_crypto_sys::psa_algorithm_t> for Hash {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl From<Hash> for psa_crypto_sys::psa_algorithm_t {
     fn from(hash: Hash) -> Self {
         match hash {
@@ -643,7 +643,7 @@ impl From<Hash> for psa_crypto_sys::psa_algorithm_t {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<psa_crypto_sys::psa_algorithm_t> for SignHash {
     type Error = Error;
     fn try_from(alg: psa_crypto_sys::psa_algorithm_t) -> Result<Self> {
@@ -655,7 +655,7 @@ impl TryFrom<psa_crypto_sys::psa_algorithm_t> for SignHash {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl From<SignHash> for psa_crypto_sys::psa_algorithm_t {
     fn from(sign_hash: SignHash) -> Self {
         match sign_hash {
@@ -665,7 +665,7 @@ impl From<SignHash> for psa_crypto_sys::psa_algorithm_t {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<psa_crypto_sys::psa_algorithm_t> for AsymmetricSignature {
     type Error = Error;
     fn try_from(alg: psa_crypto_sys::psa_algorithm_t) -> Result<Self> {
@@ -699,7 +699,7 @@ impl TryFrom<psa_crypto_sys::psa_algorithm_t> for AsymmetricSignature {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl From<AsymmetricSignature> for psa_crypto_sys::psa_algorithm_t {
     fn from(asym_sign: AsymmetricSignature) -> Self {
         match asym_sign {
@@ -723,7 +723,7 @@ impl From<AsymmetricSignature> for psa_crypto_sys::psa_algorithm_t {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<psa_crypto_sys::psa_algorithm_t> for AsymmetricEncryption {
     type Error = Error;
     fn try_from(alg: psa_crypto_sys::psa_algorithm_t) -> Result<Self> {
@@ -743,7 +743,7 @@ impl TryFrom<psa_crypto_sys::psa_algorithm_t> for AsymmetricEncryption {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl From<AsymmetricEncryption> for psa_crypto_sys::psa_algorithm_t {
     fn from(asym_encrypt: AsymmetricEncryption) -> Self {
         match asym_encrypt {

--- a/psa-crypto/src/types/key.rs
+++ b/psa-crypto/src/types/key.rs
@@ -4,15 +4,15 @@
 //! # PSA Key types
 
 #![allow(deprecated)]
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "operations")]
 use crate::initialized;
 use crate::types::algorithm::{Algorithm, Cipher};
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 use crate::types::algorithm::{AsymmetricEncryption, AsymmetricSignature};
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "operations")]
 use crate::types::status::Status;
 use crate::types::status::{Error, Result};
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 use core::convert::{TryFrom, TryInto};
 use log::error;
 pub use psa_crypto_sys::{self, psa_key_id_t, PSA_KEY_ID_USER_MAX, PSA_KEY_ID_USER_MIN};
@@ -286,7 +286,7 @@ impl Attributes {
         }
     }
 
-    #[cfg(feature = "with-mbed-crypto")]
+    #[cfg(feature = "operations")]
     pub(crate) fn reset(attributes: &mut psa_crypto_sys::psa_key_attributes_t) {
         unsafe { psa_crypto_sys::psa_reset_key_attributes(attributes) };
     }
@@ -323,7 +323,7 @@ impl Attributes {
     /// //...
     /// let key_attributes = Attributes::from_key_id(my_key_id);
     /// ```
-    #[cfg(feature = "with-mbed-crypto")]
+    #[cfg(feature = "operations")]
     pub fn from_key_id(key_id: Id) -> Result<Self> {
         initialized()?;
         let mut key_attributes = unsafe { psa_crypto_sys::psa_key_attributes_init() };
@@ -340,13 +340,13 @@ impl Attributes {
     }
 
     /// Sufficient size for a buffer to export the key, if supported
-    #[cfg(feature = "with-mbed-crypto")]
+    #[cfg(feature = "interface")]
     pub fn export_key_output_size(self) -> Result<usize> {
         Attributes::export_key_output_size_base(self.key_type, self.bits)
     }
 
     /// Sufficient size for a buffer to export the public key, if supported
-    #[cfg(feature = "with-mbed-crypto")]
+    #[cfg(feature = "interface")]
     pub fn export_public_key_output_size(self) -> Result<usize> {
         match self.key_type {
             Type::RsaKeyPair
@@ -363,7 +363,7 @@ impl Attributes {
     }
 
     /// Sufficient size for a buffer to export the given key type, if supported
-    #[cfg(feature = "with-mbed-crypto")]
+    #[cfg(feature = "interface")]
     fn export_key_output_size_base(key_type: Type, bits: usize) -> Result<usize> {
         match unsafe { psa_crypto_sys::PSA_EXPORT_KEY_OUTPUT_SIZE(key_type.try_into()?, bits) } {
             0 => Err(Error::NotSupported),
@@ -372,7 +372,7 @@ impl Attributes {
     }
 
     /// Sufficient buffer size for a signature using the given key, if the key is supported
-    #[cfg(feature = "with-mbed-crypto")]
+    #[cfg(feature = "interface")]
     pub fn sign_output_size(self, alg: AsymmetricSignature) -> Result<usize> {
         self.compatible_with_alg(alg.into())?;
         Ok(unsafe {
@@ -381,7 +381,7 @@ impl Attributes {
     }
 
     /// Sufficient buffer size for an encrypted message using the given algorithm
-    #[cfg(feature = "with-mbed-crypto")]
+    #[cfg(feature = "interface")]
     pub fn asymmetric_encrypt_output_size(self, alg: AsymmetricEncryption) -> Result<usize> {
         self.compatible_with_alg(alg.into())?;
         Ok(unsafe {
@@ -394,7 +394,7 @@ impl Attributes {
     }
 
     /// Sufficient buffer size for a decrypted message using the given algorithm
-    #[cfg(feature = "with-mbed-crypto")]
+    #[cfg(feature = "interface")]
     pub fn asymmetric_decrypt_output_size(self, alg: AsymmetricEncryption) -> Result<usize> {
         self.compatible_with_alg(alg.into())?;
         Ok(unsafe {
@@ -509,7 +509,7 @@ impl Type {
     }
 
     /// If key is public or key pair, returns the corresponding public key type.
-    #[cfg(feature = "with-mbed-crypto")]
+    #[cfg(feature = "interface")]
     pub fn key_type_public_key_of_key_pair(self) -> Result<Type> {
         match self {
             Type::RsaKeyPair
@@ -641,14 +641,13 @@ pub struct UsageFlags {
 }
 
 /// Definition of the key ID.
-#[cfg(feature = "with-mbed-crypto")]
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize, Zeroize)]
 pub struct Id {
     pub(crate) id: psa_key_id_t,
     pub(crate) handle: Option<psa_crypto_sys::psa_key_handle_t>,
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "operations")]
 impl Id {
     pub(crate) fn handle(self) -> Result<psa_crypto_sys::psa_key_handle_t> {
         Ok(match self.handle {
@@ -672,7 +671,6 @@ impl Id {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
 impl Id {
     /// Create a new Id from a persistent key ID
     pub fn from_persistent_key_id(id: u32) -> Self {
@@ -680,7 +678,7 @@ impl Id {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<Attributes> for psa_crypto_sys::psa_key_attributes_t {
     type Error = Error;
     fn try_from(attributes: Attributes) -> Result<Self> {
@@ -705,7 +703,7 @@ impl TryFrom<Attributes> for psa_crypto_sys::psa_key_attributes_t {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<psa_crypto_sys::psa_key_attributes_t> for Attributes {
     type Error = Error;
     fn try_from(attributes: psa_crypto_sys::psa_key_attributes_t) -> Result<Self> {
@@ -723,7 +721,7 @@ impl TryFrom<psa_crypto_sys::psa_key_attributes_t> for Attributes {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl From<Lifetime> for psa_crypto_sys::psa_key_lifetime_t {
     fn from(lifetime: Lifetime) -> Self {
         match lifetime {
@@ -734,7 +732,7 @@ impl From<Lifetime> for psa_crypto_sys::psa_key_lifetime_t {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl From<psa_crypto_sys::psa_key_lifetime_t> for Lifetime {
     fn from(lifetime: psa_crypto_sys::psa_key_lifetime_t) -> Self {
         match lifetime {
@@ -745,7 +743,7 @@ impl From<psa_crypto_sys::psa_key_lifetime_t> for Lifetime {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl From<UsageFlags> for psa_crypto_sys::psa_key_usage_t {
     fn from(flags: UsageFlags) -> Self {
         let mut usage_flags = 0;
@@ -771,7 +769,7 @@ impl From<UsageFlags> for psa_crypto_sys::psa_key_usage_t {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl From<psa_crypto_sys::psa_key_usage_t> for UsageFlags {
     fn from(flags: psa_crypto_sys::psa_key_usage_t) -> Self {
         UsageFlags {
@@ -789,7 +787,7 @@ impl From<psa_crypto_sys::psa_key_usage_t> for UsageFlags {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<EccFamily> for psa_crypto_sys::psa_ecc_curve_t {
     type Error = Error;
     fn try_from(family: EccFamily) -> Result<Self> {
@@ -807,7 +805,7 @@ impl TryFrom<EccFamily> for psa_crypto_sys::psa_ecc_curve_t {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<psa_crypto_sys::psa_ecc_curve_t> for EccFamily {
     type Error = Error;
     fn try_from(family: psa_crypto_sys::psa_ecc_curve_t) -> Result<Self> {
@@ -828,7 +826,7 @@ impl TryFrom<psa_crypto_sys::psa_ecc_curve_t> for EccFamily {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl From<DhFamily> for psa_crypto_sys::psa_dh_group_t {
     fn from(group: DhFamily) -> Self {
         match group {
@@ -837,7 +835,7 @@ impl From<DhFamily> for psa_crypto_sys::psa_dh_group_t {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<psa_crypto_sys::psa_dh_group_t> for DhFamily {
     type Error = Error;
     fn try_from(group: psa_crypto_sys::psa_dh_group_t) -> Result<Self> {
@@ -851,7 +849,7 @@ impl TryFrom<psa_crypto_sys::psa_dh_group_t> for DhFamily {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<Type> for psa_crypto_sys::psa_key_type_t {
     type Error = Error;
     fn try_from(key_type: Type) -> Result<Self> {
@@ -882,7 +880,7 @@ impl TryFrom<Type> for psa_crypto_sys::psa_key_type_t {
     }
 }
 
-#[cfg(feature = "with-mbed-crypto")]
+#[cfg(feature = "interface")]
 impl TryFrom<psa_crypto_sys::psa_key_type_t> for Type {
     type Error = Error;
     fn try_from(key_type: psa_crypto_sys::psa_key_type_t) -> Result<Self> {


### PR DESCRIPTION
For some use-cases, for example building a Secure Element driver, it is
only needed to have an abstraction over the PSA Crypto API include files
but not the operations. The new interface feature is made for that.

Fix #38

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>