### PR TITLE
Blocklist `max_align_t` in bindgen

### DIFF
--- a/psa-crypto-sys/build.rs
+++ b/psa-crypto-sys/build.rs
@@ -74,6 +74,7 @@ fn generate_mbed_crypto_bindings(mbed_include_dir: String) -> Result<()> {
         .clang_arg(format!("-I{}", mbed_include_dir))
         .rustfmt_bindings(true)
         .header("src/c/shim.h")
+        .blacklist_type("max_align_t")
         .generate_comments(false)
         .size_t_is_usize(true)
         .generate()


### PR DESCRIPTION
We observe the following test failure for i686:

    failures:
    ---- psa_crypto_binding::bindgen_test_layout_max_align_t stdout ----
    thread 'psa_crypto_binding::bindgen_test_layout_max_align_t'
    panicked at 'assertion failed: `(left == right)`
      left: `16`,
     right: `24`: Size of: max_align_t',
         .../build/psa-crypto-sys-59266dd2c6e5c562/out/shim_bindings.rs:3:22153

This type isn't needed, so we can just blocklist it from bindgen.