### PR TITLE
Added helper methods and changed safety of size macros

### DIFF
--- a/psa-crypto-sys/src/shim_methods.rs
+++ b/psa-crypto-sys/src/shim_methods.rs
@@ -344,10 +344,10 @@ pub unsafe fn PSA_MAC_TRUNCATED_LENGTH(alg: psa_algorithm_t) -> usize {
     psa_crypto_binding::shim_PSA_MAC_TRUNCATED_LENGTH(alg)
 }
 
-pub fn PSA_AEAD_ENCRYPT_OUTPUT_SIZE(alg: psa_algorithm_t, plaintext_bytes: usize) -> usize {
-    unsafe { psa_crypto_binding::shim_PSA_AEAD_ENCRYPT_OUTPUT_SIZE(alg, plaintext_bytes) }
+pub unsafe fn PSA_AEAD_ENCRYPT_OUTPUT_SIZE(alg: psa_algorithm_t, plaintext_bytes: usize) -> usize {
+    psa_crypto_binding::shim_PSA_AEAD_ENCRYPT_OUTPUT_SIZE(alg, plaintext_bytes)
 }
 
-pub fn PSA_AEAD_DECRYPT_OUTPUT_SIZE(alg: psa_algorithm_t, ciphertext_bytes: usize) -> usize {
-    unsafe { psa_crypto_binding::shim_PSA_AEAD_DECRYPT_OUTPUT_SIZE(alg, ciphertext_bytes) }
+pub unsafe fn PSA_AEAD_DECRYPT_OUTPUT_SIZE(alg: psa_algorithm_t, ciphertext_bytes: usize) -> usize {
+    psa_crypto_binding::shim_PSA_AEAD_DECRYPT_OUTPUT_SIZE(alg, ciphertext_bytes)
 }

--- a/psa-crypto/src/operations/aead.rs
+++ b/psa-crypto/src/operations/aead.rs
@@ -38,7 +38,7 @@ use crate::types::status::{Result, Status};
 /// };
 /// psa_crypto::init().unwrap();
 /// let my_key = key_management::import(attributes, None, &KEY_DATA).unwrap();
-/// let output_buffer_size = psa_crypto_sys::PSA_AEAD_ENCRYPT_OUTPUT_SIZE(alg.into(), INPUT_DATA.len());
+/// let output_buffer_size = attributes.aead_encrypt_output_size(alg.into(), INPUT_DATA.len()).unwrap();
 /// let mut output_buffer = vec![0; output_buffer_size];
 /// let length = aead::encrypt(my_key, alg, &NONCE, &ADDITIONAL_DATA, &INPUT_DATA, &mut output_buffer).unwrap();
 /// output_buffer.resize(length, 0);
@@ -106,7 +106,7 @@ pub fn encrypt(
 /// };
 /// psa_crypto::init().unwrap();
 /// let my_key = key_management::import(attributes, None, &KEY_DATA).unwrap();
-/// let output_buffer_size = unsafe { psa_crypto_sys::PSA_AEAD_DECRYPT_OUTPUT_SIZE(alg.into(), INPUT_DATA.len()) };
+/// let output_buffer_size = attributes.aead_decrypt_output_size(alg.into(), INPUT_DATA.len()).unwrap();
 /// let mut output_buffer = vec![0; output_buffer_size];
 /// let length = aead::decrypt(my_key, alg, &NONCE, &ADDITIONAL_DATA, &INPUT_DATA, &mut output_buffer).unwrap();
 /// output_buffer.resize(length, 0);

--- a/psa-crypto/src/operations/key_agreement.rs
+++ b/psa-crypto/src/operations/key_agreement.rs
@@ -26,7 +26,7 @@ use crate::types::status::{Result, Status};
 /// let alg = RawKeyAgreement::Ecdh;
 /// # let attributes = Attributes {
 /// #     key_type: Type::EccKeyPair {curve_family: EccFamily::SecpR1 },
-/// #     bits: 0,
+/// #     bits: 256,
 /// #     lifetime: Lifetime::Volatile,
 /// #     policy: Policy {
 /// #         usage_flags: UsageFlags {
@@ -39,7 +39,7 @@ use crate::types::status::{Result, Status};
 ///
 /// psa_crypto::init().unwrap();
 /// let my_key = key_management::import(attributes, None, &OUR_KEY_DATA).unwrap();
-/// let mut output = vec![0; 1024];
+/// let mut output = vec![0; attributes.raw_key_agreement_output_size(alg).unwrap()];
 /// let size = key_agreement::raw_key_agreement(alg, my_key, &PEER_PUBLIC_KEY, &mut output).unwrap();
 /// output.resize(size, 0);
 /// ```

--- a/psa-crypto/tests/aead.rs
+++ b/psa-crypto/tests/aead.rs
@@ -41,7 +41,7 @@ fn aead_encrypt_aes_ccm() {
     psa_crypto::init().unwrap();
     let my_key = key_management::import(attributes, None, &KEY_DATA).unwrap();
     let output_buffer_size =
-        psa_crypto_sys::PSA_AEAD_ENCRYPT_OUTPUT_SIZE(alg.into(), DECRYPTED_DATA.len());
+        unsafe { psa_crypto_sys::PSA_AEAD_ENCRYPT_OUTPUT_SIZE(alg.into(), DECRYPTED_DATA.len()) };
     let mut output_buffer = vec![0; output_buffer_size];
     let length = aead::encrypt(
         my_key,
@@ -73,7 +73,7 @@ fn aead_encrypt_aes_ccm_no_encrypt_usage_flag() {
     psa_crypto::init().unwrap();
     let my_key = key_management::import(attributes, None, &KEY_DATA).unwrap();
     let output_buffer_size =
-        psa_crypto_sys::PSA_AEAD_ENCRYPT_OUTPUT_SIZE(alg.into(), DECRYPTED_DATA.len());
+        unsafe { psa_crypto_sys::PSA_AEAD_ENCRYPT_OUTPUT_SIZE(alg.into(), DECRYPTED_DATA.len()) };
     let mut output_buffer = vec![0; output_buffer_size];
     let result = aead::encrypt(
         my_key,
@@ -104,7 +104,7 @@ fn aead_decrypt_aes_ccm() {
     psa_crypto::init().unwrap();
     let my_key = key_management::import(attributes, None, &KEY_DATA).unwrap();
     let output_buffer_size =
-        psa_crypto_sys::PSA_AEAD_DECRYPT_OUTPUT_SIZE(alg.into(), ENCRYPTED_DATA.len());
+        unsafe { psa_crypto_sys::PSA_AEAD_DECRYPT_OUTPUT_SIZE(alg.into(), ENCRYPTED_DATA.len()) };
     let mut output_buffer = vec![0; output_buffer_size];
     let length = aead::decrypt(
         my_key,
@@ -136,7 +136,7 @@ fn aead_decrypt_aes_ccm_no_decrypt_usage_flag() {
     psa_crypto::init().unwrap();
     let my_key = key_management::import(attributes, None, &KEY_DATA).unwrap();
     let output_buffer_size =
-        psa_crypto_sys::PSA_AEAD_DECRYPT_OUTPUT_SIZE(alg.into(), ENCRYPTED_DATA.len());
+        unsafe { psa_crypto_sys::PSA_AEAD_DECRYPT_OUTPUT_SIZE(alg.into(), ENCRYPTED_DATA.len()) };
     let mut output_buffer = vec![0; output_buffer_size];
     let result = aead::decrypt(
         my_key,
@@ -170,8 +170,9 @@ fn aead_decrypt_aes_ccm_invalid_signature() {
     };
     psa_crypto::init().unwrap();
     let my_key = key_management::import(attributes, None, &KEY_DATA).unwrap();
-    let output_buffer_size =
-        psa_crypto_sys::PSA_AEAD_DECRYPT_OUTPUT_SIZE(alg.into(), RANDOM_INPUT_DATA.len());
+    let output_buffer_size = unsafe {
+        psa_crypto_sys::PSA_AEAD_DECRYPT_OUTPUT_SIZE(alg.into(), RANDOM_INPUT_DATA.len())
+    };
     let mut output_buffer = vec![0; output_buffer_size];
     let result = aead::decrypt(
         my_key,


### PR DESCRIPTION
Added temporary implementation for getting output size of shared secret with EDCH algorithm (will be replaced with call to mbed TLS once it supports the macro).

Changed safety of some output size macro shim declarations as they have undefined return.


Signed-off-by: Samuel Bailey <samuel.bailey@arm.com>