### PR TITLE
Changed key derivation convertor to const function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,13 @@ jobs:
     name: All tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      - name: Install latest Rust
+        uses: actions-rs/toolchain@v1
+          with:
+            profile: minimal
+            override: true
+            toolchain: stable
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/psa-crypto/src/types/key_derivation.rs
+++ b/psa-crypto/src/types/key_derivation.rs
@@ -106,8 +106,7 @@ impl From<Inputs<'_>> for psa_crypto_sys::psa_algorithm_t {
 
 impl Inputs<'_> {
     /// Retrieve key derivation algorithm without inputs
-    pub fn key_derivation(&self) -> KeyDerivation {
-        // This can be made a const function in Rust 1.46 #[feature(const_if_match)]
+    pub const fn key_derivation(&self) -> KeyDerivation {
         match self {
             Inputs::Hkdf { hash_alg, .. } => KeyDerivation::Hkdf {
                 hash_alg: *hash_alg,


### PR DESCRIPTION
Rust v1.46 has been released which has support for match statements in a const function, so I've updated this method to be const.

Signed-off-by: Samuel Bailey <samuel.bailey@arm.com>