### PR TITLE
Remove shim_PSA_ALG_IS_FULL_LENGTH_MAC

### DIFF
--- a/psa-crypto-sys/src/c/shim.h
+++ b/psa-crypto-sys/src/c/shim.h
@@ -93,7 +93,6 @@ int shim_PSA_ALG_IS_HASH(psa_algorithm_t alg);
 int shim_PSA_ALG_IS_MAC(psa_algorithm_t alg);
 int shim_PSA_ALG_IS_HMAC(psa_algorithm_t alg);
 int shim_PSA_ALG_IS_BLOCK_CIPHER_MAC(psa_algorithm_t alg);
-int shim_PSA_ALG_IS_FULL_LENGTH_MAC(psa_algorithm_t alg);
 int shim_PSA_ALG_IS_CIPHER(psa_algorithm_t alg);
 int shim_PSA_ALG_IS_AEAD(psa_algorithm_t alg);
 int shim_PSA_ALG_IS_SIGN(psa_algorithm_t alg);

--- a/psa-crypto-sys/src/shim_methods.rs
+++ b/psa-crypto-sys/src/shim_methods.rs
@@ -85,11 +85,6 @@ pub fn PSA_ALG_IS_BLOCK_CIPHER_MAC(alg: psa_algorithm_t) -> bool {
     unsafe { psa_crypto_binding::shim_PSA_ALG_IS_BLOCK_CIPHER_MAC(alg) == 1 }
 }
 
-pub fn PSA_ALG_IS_FULL_LENGTH_MAC(alg: psa_algorithm_t) -> bool {
-    // Not in PSA spec but required to convert from psa_alg_t to algorithm/Mac
-    unsafe { psa_crypto_binding::shim_PSA_ALG_IS_FULL_LENGTH_MAC(alg) == 1 }
-}
-
 pub fn PSA_ALG_IS_CIPHER(alg: psa_algorithm_t) -> bool {
     unsafe { psa_crypto_binding::shim_PSA_ALG_IS_CIPHER(alg) == 1 }
 }


### PR DESCRIPTION
The shim was not used and nothing to link against.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>