### PR TITLE
Lower the version of bindgen to avoid conflict

### DIFF
--- a/psa-crypto-sys/Cargo.toml
+++ b/psa-crypto-sys/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/parallaxsecond/rust-psa-crypto"
 links = "mbedcrypto"
 
 [build-dependencies]
-bindgen = "0.55.1"
+bindgen = "0.54.0"
 cc = "1.0.59"
 cmake = "0.1.44"
 walkdir = "2.3.1"


### PR DESCRIPTION
The newest version needs clang-sys version 1.0.0 or above which causes
conflicts with other crates.

Signed-off-by: Hugues de Valon <hugues.devalon@arm.com>