### PR TITLE
Remove the bindgen dependency if not needed

### DIFF
--- a/psa-crypto-sys/Cargo.toml
+++ b/psa-crypto-sys/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/parallaxsecond/rust-psa-crypto"
 links = "mbedcrypto"
 
 [build-dependencies]
-bindgen = "0.54.0"
+bindgen = { version = "0.54.0", optional = true }
 cc = "1.0.59"
 cmake = "0.1.44"
 walkdir = "2.3.1"
@@ -23,5 +23,5 @@ walkdir = "2.3.1"
 [features]
 default = ["operations"]
 static = []
-interface = []
+interface = ["bindgen"]
 operations = ["interface"]


### PR DESCRIPTION
When compiling without no features, just the abstractred types are in, without any dependency on the bindgen generated types. Removing the dependency of bindgen makes the compilation of this crate faster and easier in those cases.