### PR TITLE
Add cross-compilation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,13 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: "3.x"
+      - name: Install cross-compilation toolchains
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-multilib
+          # For target: armv7-unknown-linux-gnueabihf
+          sudo apt install -y gcc-arm-linux-gnueabihf
+          # For target: aarch64-unknown-linux-gnu
+          sudo apt install -y gcc-aarch64-linux-gnu
       - name: Execute all tests
         run: ./ci.sh

--- a/ci.sh
+++ b/ci.sh
@@ -3,8 +3,7 @@
 # Copyright 2020 Contributors to the Parsec project.
 # SPDX-License-Identifier: Apache-2.0
 
-# Continuous Integration test script, executed by GitHub Actions on x86 and
-# Travis CI on Arm64.
+# Continuous Integration test script
 
 set -euf -o pipefail
 
@@ -16,6 +15,12 @@ git submodule update --init
 # Build client #
 ################
 RUST_BACKTRACE=1 cargo build
+
+# Cross-compilation tests, only the default features are tested.
+rustup target add armv7-unknown-linux-gnueabihf
+rustup target add aarch64-unknown-linux-gnu
+RUST_BACKTRACE=1 cargo build --target armv7-unknown-linux-gnueabihf
+RUST_BACKTRACE=1 cargo build --target aarch64-unknown-linux-gnu
 
 #################
 # Static checks #

--- a/psa-crypto-sys/README.md
+++ b/psa-crypto-sys/README.md
@@ -40,3 +40,14 @@ implementation-defined bits) of this crate to build for example a PSA Secure
 Element Driver. With the feature `interface`, this crate will only produce the
 implementation-defined types and their helpers/accessors using the
 `MBEDTLS_INCLUDE_DIR` variable that you need to pass.
+
+## Cross-compilation
+
+The `interface` and `operations` features need a C toolchain. When cross-compiling, the
+appropriate C toolchain will automatically be selected. Compilation will fail if it is
+not available on your system.
+
+The CI currently tests cross-compilation for the following targets:
+
+- `aarch64-unknown-linux-gnu`
+- `armv7-unknown-linux-gnueabihf`


### PR DESCRIPTION
Adds compilation of the whole workspace for two other targets. Also adds
some information in the README.md file.