### PR TITLE
build.rs: Build Mbed TLS with ENABLE_PROGRAMS=OFF, ENABLE_TESTING=OFF.

### DIFF
--- a/psa-crypto-sys/build.rs
+++ b/psa-crypto-sys/build.rs
@@ -171,6 +171,8 @@ mod operations {
         let mbed_build_path = Config::new(&mbedtls_dir)
             .cflag(format!("-I{}", out_dir))
             .cflag("-DMBEDTLS_CONFIG_FILE='<config.h>'")
+            .define("ENABLE_PROGRAMS", "OFF")
+            .define("ENABLE_TESTING", "OFF")
             .build();
 
         Ok(mbed_build_path)


### PR DESCRIPTION
In building psa-crypto-sys we never execute the Mbed TLS tests, so
there is little point in building them. By not building them we save
CPU cycles and disc space and we make these crates a little more
portable as the tests use C library facilities that are not required
by the library.