### PR TITLE
Make psa_crypto thread-safe with a global lock.

### DIFF
--- a/psa-crypto/Cargo.toml
+++ b/psa-crypto/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/parallaxsecond/rust-psa-crypto"
 [dependencies]
 psa-crypto-sys = { path = "../psa-crypto-sys", version = "0.9.0", default-features = false }
 log = "0.4.11"
+parking_lot = "0.11.2"
 serde = { version = "1.0.115", features = ["derive"] }
 # Versions 1.4.x no longer compiles with Rust version 1.46.0
 zeroize = { version = "<=1.3.0", features = ["zeroize_derive"] }

--- a/psa-crypto/src/lib.rs
+++ b/psa-crypto/src/lib.rs
@@ -73,6 +73,7 @@ static INITIALISED: AtomicBool = AtomicBool::new(false);
 #[cfg(feature = "operations")]
 pub fn init() -> Result<()> {
     // It is not a problem to call psa_crypto_init more than once.
+    let _lock = LOCK.write();
     Status::from(unsafe { psa_crypto_sys::psa_crypto_init() }).to_result()?;
     let _ = INITIALISED.store(true, Ordering::Relaxed);
 
@@ -96,3 +97,8 @@ pub fn initialized() -> Result<()> {
         Err(Error::BadState)
     }
 }
+
+#[cfg(feature = "operations")]
+use parking_lot::{const_rwlock, RwLock};
+#[cfg(feature = "operations")]
+static LOCK: RwLock<()> = const_rwlock(());

--- a/psa-crypto/src/operations/aead.rs
+++ b/psa-crypto/src/operations/aead.rs
@@ -9,6 +9,7 @@ use crate::initialized;
 use crate::types::algorithm::Aead;
 use crate::types::key::Id;
 use crate::types::status::{Result, Status};
+use crate::LOCK;
 
 /// Process an authenticated encryption operation.
 /// # Example
@@ -51,6 +52,7 @@ pub fn encrypt(
     ciphertext: &mut [u8],
 ) -> Result<usize> {
     initialized()?;
+    let _lock = LOCK.read();
 
     let mut ciphertext_size = 0;
     Status::from(unsafe {
@@ -113,6 +115,7 @@ pub fn decrypt(
     plaintext: &mut [u8],
 ) -> Result<usize> {
     initialized()?;
+    let _lock = LOCK.read();
 
     let mut plaintext_size = 0;
 

--- a/psa-crypto/src/operations/asym_encryption.rs
+++ b/psa-crypto/src/operations/asym_encryption.rs
@@ -9,6 +9,7 @@ use crate::initialized;
 use crate::types::algorithm::AsymmetricEncryption;
 use crate::types::key::Id;
 use crate::types::status::{Result, Status};
+use crate::LOCK;
 
 /// Encrypt a short message with a key pair or public key
 ///
@@ -58,6 +59,7 @@ pub fn encrypt(
     ciphertext: &mut [u8],
 ) -> Result<usize> {
     initialized()?;
+    let _lock = LOCK.read();
 
     let mut output_length = 0;
     let (salt_ptr, salt_len) = match salt {
@@ -139,6 +141,7 @@ pub fn decrypt(
     plaintext: &mut [u8],
 ) -> Result<usize> {
     initialized()?;
+    let _lock = LOCK.read();
 
     let mut output_length = 0;
     let (salt_ptr, salt_len) = match salt {

--- a/psa-crypto/src/operations/asym_signature.rs
+++ b/psa-crypto/src/operations/asym_signature.rs
@@ -9,6 +9,7 @@ use crate::initialized;
 use crate::types::algorithm::AsymmetricSignature;
 use crate::types::key::Id;
 use crate::types::status::{Result, Status};
+use crate::LOCK;
 
 /// Sign an already-calculated hash with a private key
 ///
@@ -59,6 +60,7 @@ pub fn sign_hash(
     signature: &mut [u8],
 ) -> Result<usize> {
     initialized()?;
+    let _lock = LOCK.read();
 
     let mut signature_length = 0;
 
@@ -119,6 +121,7 @@ pub fn sign_hash(
 /// ```
 pub fn verify_hash(key: Id, alg: AsymmetricSignature, hash: &[u8], signature: &[u8]) -> Result<()> {
     initialized()?;
+    let _lock = LOCK.read();
 
     Status::from(unsafe {
         psa_crypto_sys::psa_verify_hash(

--- a/psa-crypto/src/operations/hash.rs
+++ b/psa-crypto/src/operations/hash.rs
@@ -8,6 +8,7 @@
 use crate::initialized;
 use crate::types::algorithm::Hash;
 use crate::types::status::{Result, Status};
+use crate::LOCK;
 
 /// Calculate hash of a message
 ///
@@ -30,6 +31,7 @@ use crate::types::status::{Result, Status};
 /// ```
 pub fn hash_compute(hash_alg: Hash, input: &[u8], hash: &mut [u8]) -> Result<usize> {
     initialized()?;
+    let _lock = LOCK.read();
 
     let mut output_length = 0;
 
@@ -64,6 +66,7 @@ pub fn hash_compute(hash_alg: Hash, input: &[u8], hash: &mut [u8]) -> Result<usi
 /// ```
 pub fn hash_compare(hash_alg: Hash, input: &[u8], hash_to_compare: &[u8]) -> Result<()> {
     initialized()?;
+    let _lock = LOCK.read();
 
     Status::from(unsafe {
         psa_crypto_sys::psa_hash_compare(

--- a/psa-crypto/src/operations/key_agreement.rs
+++ b/psa-crypto/src/operations/key_agreement.rs
@@ -6,6 +6,7 @@ use crate::initialized;
 use crate::types::algorithm::RawKeyAgreement;
 use crate::types::key::Id;
 use crate::types::status::{Result, Status};
+use crate::LOCK;
 
 /// Perform a key agreement and return the raw shared secret.
 /// # Example
@@ -49,6 +50,8 @@ pub fn raw_key_agreement(
     output: &mut [u8],
 ) -> Result<usize> {
     initialized()?;
+    let _lock = LOCK.read();
+
     let mut output_size = 0;
     Status::from(unsafe {
         psa_crypto_sys::psa_raw_key_agreement(

--- a/psa-crypto/src/operations/key_derivation.rs
+++ b/psa-crypto/src/operations/key_derivation.rs
@@ -8,6 +8,7 @@ use crate::types::key::Attributes;
 use crate::types::key::Id;
 use crate::types::key_derivation::Operation;
 use crate::types::status::{Error, Result, Status};
+use crate::LOCK;
 use core::convert::{TryFrom, TryInto};
 
 /// This function calculates output bytes from a key derivation algorithm and uses those bytes to generate a key deterministically.
@@ -65,6 +66,7 @@ use core::convert::{TryFrom, TryInto};
 /// ```
 pub fn output_key(operation: Operation, attributes: Attributes, id: Option<u32>) -> Result<Id> {
     initialized()?;
+    let _lock = LOCK.read();
 
     let mut key_attributes = psa_crypto_sys::psa_key_attributes_t::try_from(attributes)?;
     if let Some(id) = id {

--- a/psa-crypto/src/operations/mac.rs
+++ b/psa-crypto/src/operations/mac.rs
@@ -7,7 +7,7 @@ use crate::initialized;
 use crate::types::key::Id;
 use crate::types::algorithm::Mac;
 use crate::types::status::{Result, Status, Error};
-
+use crate::LOCK;
 
 /// Calculate the message authentication code (MAC) of a message
 /// The key must allow `sign_message`
@@ -49,6 +49,7 @@ use crate::types::status::{Result, Status, Error};
 /// ```
 pub fn compute_mac(key_id: Id, mac_alg: Mac, input_message: &[u8], mac: &mut [u8]) -> Result<usize> {
     initialized()?;
+    let _lock = LOCK.read();
 
     let mut output_length = 0;
     let key_handle = key_id.handle()?;
@@ -111,6 +112,7 @@ pub fn compute_mac(key_id: Id, mac_alg: Mac, input_message: &[u8], mac: &mut [u8
 /// ```
 pub fn verify_mac(key_id: Id, mac_alg: Mac, input_message: &[u8], expected_mac: &[u8]) -> Result<()> {
     initialized()?;
+    let _lock = LOCK.read();
 
     let key_handle = key_id.handle()?;
 

--- a/psa-crypto/src/operations/other.rs
+++ b/psa-crypto/src/operations/other.rs
@@ -7,6 +7,7 @@
 
 use crate::initialized;
 use crate::types::status::{Result, Status};
+use crate::LOCK;
 
 /// Generate a buffer of random bytes.
 ///
@@ -25,6 +26,7 @@ use crate::types::status::{Result, Status};
 /// ```
 pub fn generate_random(output: &mut [u8]) -> Result<()> {
     initialized()?;
+    let _lock = LOCK.read();
 
     Status::from(unsafe { psa_crypto_sys::psa_generate_random(output.as_mut_ptr(), output.len()) })
         .to_result()?;

--- a/psa-crypto/src/types/key.rs
+++ b/psa-crypto/src/types/key.rs
@@ -12,6 +12,8 @@ use crate::types::algorithm::{Algorithm, Cipher, KeyAgreement, RawKeyAgreement};
 #[cfg(feature = "operations")]
 use crate::types::status::Status;
 use crate::types::status::{Error, Result};
+#[cfg(feature = "operations")]
+use crate::LOCK;
 #[cfg(feature = "interface")]
 use core::convert::{TryFrom, TryInto};
 use core::fmt;
@@ -350,6 +352,7 @@ impl Attributes {
     #[cfg(feature = "operations")]
     pub fn from_key_id(key_id: Id) -> Result<Self> {
         initialized()?;
+        let _lock = LOCK.read();
         let mut key_attributes = unsafe { psa_crypto_sys::psa_key_attributes_init() };
         Status::from(unsafe {
             psa_crypto_sys::psa_get_key_attributes(key_id.0, &mut key_attributes)


### PR DESCRIPTION
Current implementations of the C library, Mbed TLS, are not thread-safe,
but Rust crates are expected to be thread-safe, so we add a global
read/write lock; psa_crypto functions that use keys obtain an
appropriate lock.

Signed-off-by: Edmund Grimley Evans <edmund.grimley-evans@arm.com>