### PR TITLE
Bump zeroize version

### DIFF
--- a/psa-crypto/Cargo.toml
+++ b/psa-crypto/Cargo.toml
@@ -14,8 +14,7 @@ repository = "https://github.com/parallaxsecond/rust-psa-crypto"
 psa-crypto-sys = { path = "../psa-crypto-sys", version = "0.9.0", default-features = false }
 log = "0.4.11"
 serde = { version = "1.0.115", features = ["derive"] }
-# Versions 1.4.x no longer compiles with Rust version 1.46.0
-zeroize = { version = "<=1.3.0", features = ["zeroize_derive"] }
+zeroize = { version = "1.4.3", features = ["zeroize_derive"] }
 
 [dev-dependencies]
 rsa = { version = "0.5.0", features = ["alloc"] }


### PR DESCRIPTION
Updated to 1.4.3 not 1.5.* as the rsa crate has dependencies issue

Relates to #602

Signed-off-by: Gowtham Suresh Kumar <gowtham.sureshkumar@arm.com>