### PR TITLE
Update to remove const_err

### DIFF
--- a/psa-crypto-sys/build.rs
+++ b/psa-crypto-sys/build.rs
@@ -3,7 +3,6 @@
 
 #![deny(
     nonstandard_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,

--- a/psa-crypto/src/lib.rs
+++ b/psa-crypto/src/lib.rs
@@ -12,7 +12,6 @@
 #![cfg_attr(feature = "no-std", no_std)]
 #![deny(
     nonstandard_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,


### PR DESCRIPTION
This PR only removed `const_err` since it will be a hard error in future: https://github.com/rust-lang/rust/issues/71800

Signed-off-by: Marcus de Lima <marcus.lima@azion.com>