### PR TITLE
Disable default-features on serde

### DIFF
--- a/psa-crypto/Cargo.toml
+++ b/psa-crypto/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/parallaxsecond/rust-psa-crypto"
 psa-crypto-sys = { path = "../psa-crypto-sys", version = "0.10.0", default-features = false }
 # log v0.4.19 requires rustc 1.60.0 or newer
 log = ">=0.4.11, <0.4.19"
-serde = { version = "1.0.115", features = ["derive"] }
+serde = { version = "1.0.115", features = ["derive"], default-features = false }
 zeroize = { version = "1.4.3", features = ["zeroize_derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Serde enables by default its std features, we do not want that.