### PR TITLE
Replace the "no-std" feature with a "std" feature

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -50,9 +50,9 @@ cargo build --no-default-features
 # psa-crypto
 popd
 pushd psa-crypto
+cargo build --no-default-features --features std
+cargo build --no-default-features --features operations,std
 cargo build --no-default-features
-cargo build --no-default-features --features operations
-cargo build --no-default-features --features no-std
 
 # Test dynamic linking
 git clone https://github.com/ARMmbed/mbedtls.git

--- a/psa-crypto-sys/Cargo.toml
+++ b/psa-crypto-sys/Cargo.toml
@@ -15,6 +15,9 @@ links = "mbedcrypto"
 bindgen = { version = "0.63.0", optional = true }
 cc = "1.0.59"
 cmake = "0.1.44"
+# Without this line we get the following error:
+# `regex-syntax v0.7.2` cannot be built because it requires rustc 1.60.0 or newer
+regex = "1.7.3"
 walkdir = "2.3.1"
 
 [features]

--- a/psa-crypto/Cargo.toml
+++ b/psa-crypto/Cargo.toml
@@ -12,7 +12,8 @@ repository = "https://github.com/parallaxsecond/rust-psa-crypto"
 
 [dependencies]
 psa-crypto-sys = { path = "../psa-crypto-sys", version = "0.10.0", default-features = false }
-log = "0.4.11"
+# log v0.4.19 requires rustc 1.60.0 or newer
+log = ">=0.4.11, <0.4.19"
 serde = { version = "1.0.115", features = ["derive"] }
 zeroize = { version = "1.4.3", features = ["zeroize_derive"] }
 

--- a/psa-crypto/Cargo.toml
+++ b/psa-crypto/Cargo.toml
@@ -22,7 +22,7 @@ rand = "0.8.4"
 base64 = "0.12.3"
 
 [features]
-default = ["operations", "no-std"]
+default = ["operations"]
 operations = ["psa-crypto-sys/operations", "interface"]
 interface = ["psa-crypto-sys/interface"]
-no-std = []
+std = []

--- a/psa-crypto/src/lib.rs
+++ b/psa-crypto/src/lib.rs
@@ -9,7 +9,7 @@
 //! for a more complete description of operations and types.
 //! This abstraction is built on top of the `psa-crypto-sys` crate.
 
-#![cfg_attr(feature = "no-std", no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
     nonstandard_style,
     dead_code,

--- a/psa-crypto/src/types/status.rs
+++ b/psa-crypto/src/types/status.rs
@@ -8,7 +8,7 @@
 use log::error;
 use zeroize::Zeroize;
 
-#[cfg(not(feature = "no-std"))]
+#[cfg(feature = "std")]
 use std::fmt;
 
 /// Result type returned by any PSA operation
@@ -92,7 +92,7 @@ pub enum Error {
     InvalidHandle,
 }
 
-#[cfg(not(feature = "no-std"))]
+#[cfg(feature = "std")]
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -156,7 +156,7 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(not(feature = "no-std"))]
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 impl From<Error> for Status {


### PR DESCRIPTION
Negative feature names are rejected by Clippy: they cause confusion when several crates depend on the same crate but with different sets of features.

The default set of features is changed but anyone who specifies `--no-default-features` or `default-features = false` will need to change what features they specify, so this is an incompatible change.

Also update toolchain from 1.58.1 to 1.60.0 in `.github/workflows/ci.yml` as `regex-syntax` v0.7.2 requires `rustc` 1.60.0 or newer.