### PR TITLE
Remove private_in_public lint.

### DIFF
--- a/psa-crypto-sys/build.rs
+++ b/psa-crypto-sys/build.rs
@@ -10,7 +10,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     unconditional_recursion,
     unused,
     unused_allocation,

--- a/psa-crypto/src/lib.rs
+++ b/psa-crypto/src/lib.rs
@@ -19,7 +19,6 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
     unconditional_recursion,
     unused,
     unused_allocation,


### PR DESCRIPTION
The nightly CI test "cargo +nightly udeps --workspace" failed with:
    lint `private_in_public` has been removed: replaced with another
    group of lints, see RFC
    <https://rust-lang.github.io/rfcs/2145-type-privacy.html> for more
    information

But the replacement lints are not available with rustc 1.60.0 so just remove private_in_public for now.

BUT WAIT, DON'T MERGE THIS YET, because there's perhaps an alternative to consider; I think you can tell it to ignore unrecognised lints, which might be a better solution. Here's the alternative: #120