### PR TITLE
Add some lints and allow(unknown_lints).

### DIFF
--- a/psa-crypto-sys/build.rs
+++ b/psa-crypto-sys/build.rs
@@ -1,6 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(unknown_lints)]
 #![deny(
     nonstandard_style,
     dead_code,
@@ -10,8 +11,12 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
+    private_bounds,
     private_in_public,
+    private_interfaces,
+    renamed_and_removed_lints,
     unconditional_recursion,
+    unnameable_types,
     unused,
     unused_allocation,
     unused_comparisons,

--- a/psa-crypto/src/lib.rs
+++ b/psa-crypto/src/lib.rs
@@ -10,6 +10,7 @@
 //! This abstraction is built on top of the `psa-crypto-sys` crate.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![allow(unknown_lints)]
 #![deny(
     nonstandard_style,
     dead_code,
@@ -19,8 +20,12 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
+    private_bounds,
     private_in_public,
+    private_interfaces,
+    renamed_and_removed_lints,
     unconditional_recursion,
+    unnameable_types,
     unused,
     unused_allocation,
     unused_comparisons,


### PR DESCRIPTION
The nightly CI test "cargo +nightly udeps --workspace" failed with:
    lint `private_in_public` has been removed: replaced with another
    group of lints, see RFC
    <https://rust-lang.github.io/rfcs/2145-type-privacy.html> for more
    information

We leave the old lint for the benefit of old rustc versions and add some of the replacement lints, also adding #![allow(unknown_lints)].

This is an alternative to #119.