### PR TITLE
Add allow(renamed_and_removed_lints).

### DIFF
--- a/psa-crypto-sys/build.rs
+++ b/psa-crypto-sys/build.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 Contributors to the Parsec project.
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(unknown_lints)]
+#![allow(renamed_and_removed_lints, unknown_lints)]
 #![deny(
     nonstandard_style,
     dead_code,

--- a/psa-crypto/src/lib.rs
+++ b/psa-crypto/src/lib.rs
@@ -10,7 +10,7 @@
 //! This abstraction is built on top of the `psa-crypto-sys` crate.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![allow(unknown_lints)]
+#![allow(renamed_and_removed_lints, unknown_lints)]
 #![deny(
     nonstandard_style,
     dead_code,


### PR DESCRIPTION
It seems that we sometimes need this in addition to unknown_lints.

(I do not know why I didn't observe this problem yesterday when doing #120.)