### PR TITLE
ci.yml: Correct the Rust compiler version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,12 @@ name: Continuous Integration
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  build-1-60-0:
-    name: "All tests: rustc 1.66.0"
+  build-msrv:
+    name: "All tests: rustc MSRV"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Rust 1.66.0
+      - name: Install Rust MSRV
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.66.0


### PR DESCRIPTION
The Rust compiler version according is incorrect in the job name 'build-1-60-0', it should be 'build-1-66-0'. However, to be more generic and for better maintainability:

 * Change the job name to 'build-msrv'
 * Replace occurrences of the Rust version with MSRV in all possible places.