### PR TITLE
Bump bindgen to 0.69.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,17 +31,17 @@ checksum = "e6b4d9b1225d28d360ec6a231d65af1fd99a2a095154c8040689617290569c5c"
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
+ "itertools",
  "lazy_static",
  "lazycell",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -208,6 +208,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,12 +340,6 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem-rfc7468"
@@ -565,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"

--- a/psa-crypto-sys/Cargo.toml
+++ b/psa-crypto-sys/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/parallaxsecond/rust-psa-crypto"
 rust-version = "1.66.0"
 
 [build-dependencies]
-bindgen = { version = "0.66.1", optional = true }
+bindgen = { version = "0.69.4", optional = true }
 cc = "1.0.59"
 cmake = "0.1.44"
 regex = "1.9.1"

--- a/psa-crypto-sys/src/lib.rs
+++ b/psa-crypto-sys/src/lib.rs
@@ -23,6 +23,7 @@
 #[allow(clippy::all)]
 #[cfg(feature = "interface")]
 mod psa_crypto_binding {
+    #![allow(unused_imports)]
     include!(concat!(env!("OUT_DIR"), "/shim_bindings.rs"));
 }
 

--- a/psa-crypto/src/operations/cipher.rs
+++ b/psa-crypto/src/operations/cipher.rs
@@ -32,7 +32,8 @@ fn crypt(
 
     let mut output_length = 0;
     let mut output_length_finish = 0;
-    match (|| {
+
+    let status = {
         Status::from(unsafe {
             psa_crypto_sys::psa_cipher_set_iv(&mut operation, iv.as_ptr(), iv.len())
         })
@@ -61,16 +62,16 @@ fn crypt(
         .to_result()?;
 
         Ok(())
-    })() {
-        Ok(()) => (),
+    };
+
+    match status {
+        Ok(()) => Ok(output_length + output_length_finish),
         Err(x) => {
             Status::from(unsafe { psa_crypto_sys::psa_cipher_abort(&mut operation) })
                 .to_result()?;
-            return Err(x);
+            Err(x)
         }
     }
-
-    Ok(output_length + output_length_finish)
 }
 
 /// Encrypt a short message with a key

--- a/psa-crypto/src/types/key_derivation.rs
+++ b/psa-crypto/src/types/key_derivation.rs
@@ -8,7 +8,7 @@ use super::key::Id;
 #[cfg(feature = "operations")]
 use super::status::{Error, Result, Status};
 #[cfg(feature = "operations")]
-use core::convert::{From, TryFrom};
+use core::convert::TryFrom;
 
 /// Key derivation operation for deriving keys from existing sources
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
- This is to go in line with other parallaxsecond repositories, in preparation for the next parsec release.
- 
- Solve other issues to fix nightly