### PR TITLE
build: make psa-crypto-sys no_std, fix zeroize with no_std

### DIFF
--- a/psa-crypto-sys/build.rs
+++ b/psa-crypto-sys/build.rs
@@ -171,6 +171,7 @@ mod common {
             .clang_arg(format!("-I{mbed_include_dir}"))
             .header("src/c/shim.h")
             .blocklist_type("max_align_t")
+            .use_core()
             .generate_comments(false)
             .size_t_is_usize(true);
 

--- a/psa-crypto-sys/src/lib.rs
+++ b/psa-crypto-sys/src/lib.rs
@@ -7,6 +7,7 @@
 //! You can find the API
 //! [here](https://developer.arm.com/architectures/security-architectures/platform-security-architecture/documentation).
 
+#![no_std]
 // This one is hard to avoid.
 #![allow(clippy::multiple_crate_versions)]
 #![allow(clippy::missing_safety_doc)]

--- a/psa-crypto/Cargo.toml
+++ b/psa-crypto/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.66.0"
 psa-crypto-sys = { path = "../psa-crypto-sys", version = "0.12.0", default-features = false }
 log = "0.4.20"
 serde = { version = "1.0.115", features = ["derive"], default-features = false }
-zeroize = { version = "1.4.3", features = ["zeroize_derive"] }
+zeroize = { version = "1.4.3", features = ["zeroize_derive"], default-features = false }
 
 [dev-dependencies]
 rsa = { version = "0.5.0", features = ["alloc"] }


### PR DESCRIPTION
As psa-crypto-sys does not rely on any std features, it should be safe
to completely switch its bindgen options to use core, and mark it as
no_std. This allows this crate to be used in embedded applications such
as TrustedFirmware-M Secure Partitions.

zeroize should not need `alloc` default feature, as this crate does not
make use of Vec or Box and does not derive zeroize on them. Disable all
default features to avoid unnecessary dependency on std.

Tested to provide access to hash functions via `operations` feature in
a TF-M Secure Partition sample.

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
