### PR TITLE
build: fixes for newer Rust

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -59,7 +59,7 @@ git clone https://github.com/ARMmbed/mbedtls.git
 pushd mbedtls
 git checkout v3.0.0
 ./scripts/config.py crypto
-SHARED=1 make
+SHARED=1 make -j$(nproc)
 popd
 
 # Clean before to only build the interface

--- a/psa-crypto-sys/build.rs
+++ b/psa-crypto-sys/build.rs
@@ -160,15 +160,15 @@ mod common {
     ) -> Result<()> {
         let header = mbed_include_dir.clone() + "/psa/crypto.h";
 
-        println!("using mbedtls include directory of: {}", mbed_include_dir);
-        println!("cargo:rerun-if-changed={}", header);
+        println!("using mbedtls include directory of: {mbed_include_dir}");
+        println!("cargo:rerun-if-changed={header}");
 
         let out_dir = env::var("OUT_DIR").unwrap();
 
         // Common shim builder settings
         let mut shim_builder = bindgen::Builder::default()
-            .clang_arg(format!("-I{}", out_dir))
-            .clang_arg(format!("-I{}", mbed_include_dir))
+            .clang_arg(format!("-I{out_dir}"))
+            .clang_arg(format!("-I{mbed_include_dir}"))
             .header("src/c/shim.h")
             .blocklist_type("max_align_t")
             .generate_comments(false)
@@ -181,7 +181,7 @@ mod common {
 
         if !external_mbedtls {
             shim_builder =
-                shim_builder.clang_arg(format!("-DMBEDTLS_CONFIG_FILE=\"{}\"", CONFIG_FILE));
+                shim_builder.clang_arg(format!("-DMBEDTLS_CONFIG_FILE=\"{CONFIG_FILE}\""));
         }
 
         // Build the bindings
@@ -219,7 +219,8 @@ mod common {
             .cargo_metadata(metadata);
 
         if !external_mbedtls {
-            _ = cfg.flag(&format!("-DMBEDTLS_CONFIG_FILE=\"{}\"", CONFIG_FILE));
+            let mbedtls_config_define = format!("-DMBEDTLS_CONFIG_FILE=\"{CONFIG_FILE}\"");
+            _ = cfg.flag(&mbedtls_config_define);
         }
 
         cfg.try_compile(shimlib_name)
@@ -319,7 +320,7 @@ mod operations {
 
         // Build the MbedTLS libraries
         let mbed_build_path = Config::new(&mbedtls_dir)
-            .cflag(format!("-I{}", out_dir))
+            .cflag(format!("-I{out_dir}"))
             .cflag(format!(
                 "-DMBEDTLS_CONFIG_FILE='\"{}\"'",
                 common::CONFIG_FILE
@@ -336,8 +337,8 @@ mod operations {
         let link_type = if link_statically { "static" } else { "dylib" };
 
         // Request rustc to link the Mbed Crypto library
-        println!("cargo:rustc-link-search=native={}", lib_path,);
-        println!("cargo:rustc-link-lib={}=mbedcrypto", link_type);
+        println!("cargo:rustc-link-search=native={lib_path}",);
+        println!("cargo:rustc-link-lib={link_type}=mbedcrypto");
     }
 
     #[cfg(not(feature = "prefix"))]

--- a/psa-crypto-sys/src/lib.rs
+++ b/psa-crypto-sys/src/lib.rs
@@ -21,6 +21,8 @@
     trivial_casts
 )]
 #[allow(clippy::all)]
+#[allow(unknown_lints)] // unnecessary_transmutes is only present in 1.88+
+#[allow(unnecessary_transmutes)]
 #[cfg(feature = "interface")]
 mod psa_crypto_binding {
     #![allow(unused_imports)]

--- a/psa-crypto/src/types/key.rs
+++ b/psa-crypto/src/types/key.rs
@@ -60,7 +60,7 @@ impl Attributes {
     ///         }),
     ///     },
     /// };
-
+    ///
     /// // Can not export because the export flag is set to false.
     /// attributes.can_export().unwrap_err();
     /// ```
@@ -237,7 +237,7 @@ impl Attributes {
     ///         permitted_algorithms: permitted_alg,
     ///     },
     /// };
-
+    ///
     /// assert!(attributes.is_compatible_with_alg(alg));
     /// attributes.key_type = Type::RsaPublicKey;
     /// assert!(attributes.is_compatible_with_alg(alg));
@@ -562,15 +562,15 @@ impl fmt::Display for Type {
             Type::Chacha20 => write!(f, "Key for an algorithm based on ChaCha20"),
             Type::RsaPublicKey => write!(f, "RSA public key"),
             Type::RsaKeyPair => write!(f, "RSA key pair"),
-            Type::EccKeyPair { curve_family } => write!(f, "ECC key pair (using {})", curve_family),
+            Type::EccKeyPair { curve_family } => write!(f, "ECC key pair (using {curve_family})"),
             Type::EccPublicKey { curve_family } => {
-                write!(f, "ECC public key (using {})", curve_family)
+                write!(f, "ECC public key (using {curve_family})")
             }
             Type::DhKeyPair { group_family } => {
-                write!(f, "Diffie-Hellman key pair (using {})", group_family)
+                write!(f, "Diffie-Hellman key pair (using {group_family})")
             }
             Type::DhPublicKey { group_family } => {
-                write!(f, "Diffie-Hellman public key (using {})", group_family)
+                write!(f, "Diffie-Hellman public key (using {group_family})")
             }
         }
     }


### PR DESCRIPTION
Adapt newest best practices according to Clippy, fix compiler warnings.

Also build mbedTLS concurrently for faster CI builds.

Signed-off-by: Dmitrii Sharshakov <d3dx12.xx@gmail.com>
