### PR TITLE
upgrade base64 to 0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"

--- a/psa-crypto/Cargo.toml
+++ b/psa-crypto/Cargo.toml
@@ -20,7 +20,7 @@ zeroize = { version = "1.4.3", features = ["zeroize_derive"], default-features =
 [dev-dependencies]
 rsa = { version = "0.5.0", features = ["alloc"] }
 rand = "0.8.4"
-base64 = "0.12.3"
+base64 = "0.22.1"
 
 [features]
 default = ["operations"]


### PR DESCRIPTION
based on: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/psa-crypto/debian/patches/relax-dep.diff?ref_type=heads